### PR TITLE
Removed unused variables to address warnings

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,7 +11,7 @@ dependencies:
   - nlohmann_json
   - cppzmq
   - xtl
-  - clangdev >=16
+  - clangdev >=16,<17
   - pugixml
   - cpp-argparse
   - zlib

--- a/src/xinspect.hpp
+++ b/src/xinspect.hpp
@@ -160,7 +160,6 @@ namespace xcpp
                     tagfile = it->at("tagfile");
                     std::string filename = tagfiles_dir + "/" + tagfile;
                     pugi::xml_document doc;
-                    pugi::xml_parse_result result = doc.load_file(filename.c_str());
                     class_member_predicate predicate{typename_, "function", method[2]};
                     auto node = doc.find_node(predicate);
                     if (!node.empty())
@@ -194,7 +193,6 @@ namespace xcpp
                 tagfile = it->at("tagfile");
                 std::string filename = tagfiles_dir + "/" + tagfile;
                 pugi::xml_document doc;
-                pugi::xml_parse_result result = doc.load_file(filename.c_str());
                 for (auto c : check)
                 {
                     node_predicate predicate{c, find_string};

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -282,7 +282,7 @@ namespace xcpp
     }
 
     nl::json interpreter::execute_request_impl(
-        int execution_counter,
+        int /*execution_counter*/,
         const std::string& code,
         bool silent,
         bool /*store_history*/,
@@ -414,7 +414,7 @@ namespace xcpp
         return kernel_res;
     }
 
-    nl::json interpreter::complete_request_impl(const std::string& code, int cursor_pos)
+    nl::json interpreter::complete_request_impl(const std::string& /*code*/, int cursor_pos)
     {
         return xeus::create_complete_reply(
             nl::json::array(), /*matches*/
@@ -436,7 +436,7 @@ namespace xcpp
         return kernel_res;
     }
 
-    nl::json interpreter::is_complete_request_impl(const std::string& code)
+    nl::json interpreter::is_complete_request_impl(const std::string& /*code*/)
     {
         return xeus::create_is_complete_reply("complete", "   ");
     }

--- a/src/xsystem.hpp
+++ b/src/xsystem.hpp
@@ -32,8 +32,6 @@ namespace xcpp
             std::smatch to_execute;
             std::regex_search(code, to_execute, re);
 
-            int ret = 1;
-
             // Redirection of stderr to stdout
             std::string command = to_execute.str(1) + " 2>&1";
 
@@ -45,7 +43,6 @@ namespace xcpp
             if (shell_result)
             {
                 char buff[512];
-                ret = 0;
                 while (fgets(buff, sizeof(buff), shell_result))
                 {
                     std::cout << buff;


### PR DESCRIPTION
The build using the make command is quite messy (as there are lot of warnings due to unused variables). This PR gets rid of them.