### PR TITLE
Update xeus-cpp dependency from clangdev 16 to 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ mamba install`xeus-cpp` notebook -c conda-forge
 Or you can install it from the sources, you will first need to install dependencies
 
 ```bash
-mamba install cmake cxx-compiler xeus-zmq nlohmann_json cppzmq xtl jupyterlab clangdev=16 cpp-argparse pugixml -c conda-forge
+mamba install cmake cxx-compiler xeus-zmq nlohmann_json cppzmq xtl jupyterlab clangdev=17 cpp-argparse pugixml -c conda-forge
 ```
 
 Then you can compile the sources (replace `$CONDA_PREFIX` with a custom installation

--- a/docs/InstallationAndUsage.rst
+++ b/docs/InstallationAndUsage.rst
@@ -6,7 +6,7 @@ You will first need to install dependencies.
 .. code-block:: bash
 
     mamba install cmake cxx-compiler xeus-zmq nlohmann_json cppzmq xtl jupyterlab
-    clangdev=16 cpp-argparse pugixml -c conda-forge
+    clangdev=17 cpp-argparse pugixml -c conda-forge
 
 
 **Note:** Use a mamba environment with python version >= 3.11 for fetching clang-versions.

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,7 +11,7 @@ dependencies:
   - nlohmann_json
   - cppzmq
   - xtl
-  - clangdev >=16,<17
+  - clangdev >=17,<18
   - pugixml
   - cpp-argparse
   - zlib


### PR DESCRIPTION
This PR fixes the **make && make install** build failures while using **clang 17.0.4** and **llvm 17.0.4**. The main changes here are inspired by (https://github.com/llvm/llvm-project/commit/b8e5f918166c46f8b3c0674f2a2e81bfcb95f969 and https://github.com/llvm/llvm-project/commit/8b1771bd9f304be39d4dcbdcccedb6d3bcd18200) as 
`ExecutorAddr` was introduced in  as an eventual replacement for `JITTargetAddress` and `ExecutorSymbolDef` was introduced as a 
replacement for `JITEvaluatedSymbol` in the following patches.