### PR TITLE
Removed is_inspect_request call from execute request

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -327,16 +327,8 @@ namespace xcpp
         // Attempt normal evaluation
         
         try
-        {   std::string exp = R"(\w*(?:\:{2}|\<.*\>|\(.*\)|\[.*\])?)";
-            std::regex re(R"((\w*(?:\:{2}|\<.*\>|\(.*\)|\[.*\])?)(\.?)*$)");
-            auto inspect_request = is_inspect_request(code, re);
-            if (inspect_request.first)
-            {
-                inspect(inspect_request.second[0], kernel_res, *m_interpreter);
-            }
-            
+        {
             compilation_result = process_code(*m_interpreter, code, error_stream);
-        
         }
         catch (std::exception& e)
         {
@@ -427,7 +419,7 @@ namespace xcpp
     {
         nl::json kernel_res;
         std::string exp = R"(\w*(?:\:{2}|\<.*\>|\(.*\)|\[.*\])?)";
-        std::regex re(R"((\w*(?:\:{2}|\<.*\>|\(.*\)|\[.*\])?)(\.?)*$)");
+        std::regex re{"(" + exp + R"(\.?)*$)"};
         auto inspect_request = is_inspect_request(code.substr(0, cursor_pos), re);
         if (inspect_request.first)
         {


### PR DESCRIPTION
As discussed, we don't really need an `is_inspect_request` call inside the execute request implementation. Which ends up giving us something like 
![image](https://github.com/compiler-research/xeus-cpp/assets/87052487/196e5008-6a02-4311-8937-68b8d64ea1f2)

Now that has been addressed 
<img width="695" alt="image" src="https://github.com/compiler-research/xeus-cpp/assets/87052487/0ae9ff02-b7cc-4576-8091-5dec571c1274">

