### PR TITLE
Fix extract_filename function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ set(XEUS_CPP_SRC
     src/xinterpreter.cpp
     src/xoptions.cpp
     src/xparser.cpp
+    src/xutils.cpp
 )
 
 if(EMSCRIPTEN)

--- a/include/xeus-cpp/xbuffer.hpp
+++ b/include/xeus-cpp/xbuffer.hpp
@@ -52,7 +52,7 @@ namespace xcpp
         {
             std::lock_guard<std::mutex> lock(m_mutex);
             // Called for a string of characters.
-            m_output.append(s, count);
+            m_output.append(s, static_cast<std::size_t>(count));
             return count;
         }
 

--- a/include/xeus-cpp/xutils.hpp
+++ b/include/xeus-cpp/xutils.hpp
@@ -1,0 +1,37 @@
+/************************************************************************************
+ * Copyright (c) 2023, xeus-cpp contributors                                        *
+ *                                                                                  *
+ * Distributed under the terms of the BSD 3-Clause License.                         *
+ *                                                                                  *
+ * The full license is in the file LICENSE, distributed with this software.         *
+ ************************************************************************************/
+
+#ifndef XEUS_CPP_UTILS_HPP
+#define XEUS_CPP_UTILS_HPP
+
+#include "xinterpreter.hpp"
+
+using interpreter_ptr = std::unique_ptr<xcpp::interpreter>;
+
+namespace xcpp
+{
+
+#ifdef __GNUC__
+    XEUS_CPP_API
+    void handler(int sig);
+#endif
+
+    XEUS_CPP_API
+    void stop_handler(int sig);
+
+    XEUS_CPP_API
+    bool should_print_version(int argc, char* argv[]);
+
+    XEUS_CPP_API
+    std::string extract_filename(int &argc, char* argv[]);
+
+    XEUS_CPP_API
+    interpreter_ptr build_interpreter(int argc, char** argv);
+}
+
+#endif

--- a/src/xutils.cpp
+++ b/src/xutils.cpp
@@ -1,0 +1,99 @@
+/************************************************************************************
+ * Copyright (c) 2023, xeus-cpp contributors                                        *
+ *                                                                                  *
+ * Distributed under the terms of the BSD 3-Clause License.                         *
+ *                                                                                  *
+ * The full license is in the file LICENSE, distributed with this software.         *
+ ************************************************************************************/
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <signal.h>
+
+#ifdef __GNUC__
+#include <stdio.h>
+#ifndef XEUS_CPP_EMSCRIPTEN_WASM_BUILD
+#include <execinfo.h>
+#endif
+#include <stdlib.h>
+#include <unistd.h>
+#endif
+
+
+#include "xeus-cpp/xutils.hpp"
+#include "xeus-cpp/xinterpreter.hpp"
+
+namespace xcpp
+{
+
+#if defined(__GNUC__) && !defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+    void handler(int sig)
+    {
+        void* array[10];
+
+        // get void*'s for all entries on the stack
+        std::size_t size = backtrace(array, 10);
+
+        // print out all the frames to stderr
+        fprintf(stderr, "Error: signal %d:\n", sig);
+        backtrace_symbols_fd(array, size, STDERR_FILENO);
+        exit(1);
+    }
+#endif
+
+    void stop_handler(int /*sig*/)
+    {
+        exit(0);
+    }
+
+    bool should_print_version(int argc, char* argv[])
+    {
+        for (int i = 0; i < argc; ++i)
+        {
+            if (std::string(argv[i]) == "--version")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::string extract_filename(int &argc, char* argv[])
+    {
+        std::string res = "";
+        for (int i = 0; i < argc; ++i)
+        {
+            if ((std::string(argv[i]) == "-f") && (i + 1 < argc))
+            {
+                res = argv[i + 1];
+                for (int j = i; j < argc - 2; ++j)
+                {
+                    argv[j] = argv[j + 2];
+                }
+                argc -= 2;
+                break;
+            }
+        }
+        return res;
+    }
+
+    interpreter_ptr build_interpreter(int argc, char** argv)
+    {
+        int interpreter_argc = argc;  // + 1;
+        const char** interpreter_argv = new const char*[interpreter_argc];
+        interpreter_argv[0] = "xeus-cpp";
+        // Copy all arguments in the new array excepting the process name.
+        for (int i = 1; i < argc; i++)
+        {
+            interpreter_argv[i] = argv[i];
+        }
+
+        interpreter_ptr interp_ptr = std::make_unique<interpreter>(interpreter_argc, interpreter_argv);
+        delete[] interpreter_argv;
+        return interp_ptr;
+    }
+
+}

--- a/test/test_interpreter.cpp
+++ b/test/test_interpreter.cpp
@@ -8,6 +8,7 @@
 
 #include "doctest/doctest.h"
 #include "xeus-cpp/xinterpreter.hpp"
+#include "xeus-cpp/xutils.hpp"
 
 TEST_SUITE("execute_request")
 {
@@ -32,5 +33,18 @@ TEST_SUITE("execute_request")
         REQUIRE(result["user_expressions"] == nl::json::object());
         REQUIRE(result["found"] == true);
         REQUIRE(result["status"] == "ok");
+    }
+}
+
+TEST_SUITE("extract_filename")
+{
+    TEST_CASE("extract_filename_basic_test")
+    {
+        const char* arguments[] = {"argument1", "-f", "filename.txt", "argument4"};
+        int argc = sizeof(arguments) / sizeof(arguments[0]);
+
+        std::string result = xcpp::extract_filename(argc, const_cast<char**>(arguments));
+        REQUIRE(result == "filename.txt");
+        REQUIRE(argc == 2);
     }
 }


### PR DESCRIPTION
If the `extract_filename` function is going to be editing `argv`, then it also needs to make a corresponding change to `argc`. Can lead to inconsistencies otherwise.