### PR TITLE
Update clang tidy workflow actions

### DIFF
--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Post review comments
         id: post-review
-        uses: ZedThree/clang-tidy-review/post@v0.13.2
+        uses: ZedThree/clang-tidy-review/post@v0.18.0
         with:
           max_comments: 10
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
+        uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "12.0.0"
+          version: "18.1.3"
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.13.2
+        uses: ZedThree/clang-tidy-review@v0.18.0
         id: review
         with:
           build_dir: build
@@ -43,4 +43,4 @@ jobs:
             cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=On
 
       - name: Upload artifacts
-        uses: ZedThree/clang-tidy-review/upload@v0.13.1
+        uses: ZedThree/clang-tidy-review/upload@v0.18.0


### PR DESCRIPTION
@vgvassilev This PR updates the clang tidy workflow to match that in CppInterOp and Clad. It is ready for merging.