### PR TITLE
Update example notebook to use c++17 kernel

### DIFF
--- a/notebooks/xeus-cpp.ipynb
+++ b/notebooks/xeus-cpp.ipynb
@@ -127,16 +127,16 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "C++ 14 (xcpp)",
+   "display_name": "C++17 (xcpp)",
    "language": "cpp",
-   "name": "xcpp"
+   "name": "C++17 (xcpp)"
   },
   "language_info": {
    "codemirror_mode": "text/x-c++src",
    "file_extension": ".cpp",
    "mimetype": "text/x-c++src",
    "name": "c++",
-   "version": "14"
+   "version": "17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Previously the example notebook made use of the C++14 kernel . This PR updates it to use the C++17 kernel.