### PR TITLE
Display Binder link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,11 @@ cmake .. -D CMAKE_PREFIX_PATH=$CONDA_PREFIX -D CMAKE_INSTALL_PREFIX=$CONDA_PREFI
 make && make install
 ```
 
-<!-- ## Trying it online
+## Trying it online
 
 To try out xeus-cpp interactively in your web browser, just click on the binder link:
-(Once Conda Package is Ready)
 
-[![Binder](binder-logo.svg)](https://mybinder.org/v2/gh/compiler-research/xeus-cpp/main?urlpath=/lab/tree/notebooks/xeus-cpp.ipynb) -->
+[![Binder](binder-logo.svg)](https://mybinder.org/v2/gh/compiler-research/xeus-cpp/main?urlpath=/lab/tree/notebooks/xeus-cpp.ipynb) 
 
 ## Documentation
 


### PR DESCRIPTION
Now that xeus-cpp has a Conda package the Binder link can be displayed in the readme