### PR TITLE
Remove kernelspec from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,6 @@
 # Python
 __pycache__/
 
-# Generated kernelspec
-share/jupyter/kernels/xcpp/kernel.json
-
 # Build directory
 build/
 


### PR DESCRIPTION
Previously xeus-cpp only had one kernel. This PR updates the .gitignore to take into account there are now multiple kernels.