### PR TITLE
Treat all warnings as errors (non wasm)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,7 @@ jobs:
            -DCMAKE_PREFIX_PATH=$CONDA_PREFIX \
            -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
            -DXEUS_CPP_ENABLE_CODE_COVERAGE=${{ matrix.coverage }} \
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON            \
            ${{ matrix.extra_cmake_flags }} 
 
       - name: build & install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.24)
 project(xeus-cpp)
 
 enable_language(CXX)

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -101,8 +101,8 @@ int __get_cxx_version () {
 __get_cxx_version ()
       )";
 
-      long cxx_version = Cpp::Evaluate(code);
-      return std::to_string(cxx_version);
+        auto cxx_version = Cpp::Evaluate(code);
+        return std::to_string(cxx_version);
     }
 
 
@@ -137,6 +137,9 @@ __get_cxx_version ()
     )
     {
         nl::json kernel_res;
+
+
+        auto input_guard = input_redirection(allow_stdin);
 
         // Check for magics
         for (auto& pre : preamble_manager.preamble)


### PR DESCRIPTION
The PR will change it so when building xeus-cpp it treats all warnings as errors by default. In the ci I turn this off for wasm builds.