### PR TITLE
Upgrade example notebook to C++20 kernel

### DIFF
--- a/notebooks/xeus-cpp.ipynb
+++ b/notebooks/xeus-cpp.ipynb
@@ -127,16 +127,16 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "C++17 (xcpp)",
+   "display_name": "C++20 (xcpp)",
    "language": "cpp",
-   "name": "C++17 (xcpp)"
+   "name": "xcpp20"
   },
   "language_info": {
    "codemirror_mode": "text/x-c++src",
    "file_extension": ".cpp",
    "mimetype": "text/x-c++src",
    "name": "c++",
-   "version": "17"
+   "version": "20"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@vgvassilev @alexander-penev This upgrades the example notebook to use the C++20 kernel now that it is available. I corrected the name, as I made a mistake when upgrading it to C++17.