### PR TITLE
Fix deprecation warning --current-env

### DIFF
--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 testpaths = test
-addopts = --nbval --current-env
+addopts = --nbval-current-env 


### PR DESCRIPTION
There is currently a warning when the ci which states
DeprecationWarning: --current-env has been renamed to --nbval-current-env
This PR fixes this warning.