### PR TITLE
fix jupyter kernel test on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
           cd build
           make install -j ${{ env.ncpus }}
 
-      - name: Test xeus-cpp C++
+      - name: Test xeus-cpp C++ Unix Systems
         if: ${{ runner.os != 'windows' }}
         shell: bash -l {0}
         run: |
@@ -126,12 +126,28 @@ jobs:
           ./test_xeus_cpp
         timeout-minutes: 4
 
-      - name: test
+      - name: Test xeus-cpp C++ Windows Systems
+        if: ${{ runner.os == 'windows' }}
+        shell: cmd /C call {0}
+        run: |
+          call C:\Users\runneradmin\micromamba-root\condabin\micromamba.bat activate xeus-cpp
+          cd build\test
+          .\test_xeus_cpp.exe
+
+      - name: Python tests Unix Systems
         if: ${{ runner.os != 'windows' }}
         shell: bash -l {0}
         run: |
           cd test
           pytest -sv .  --reruns 5
+  
+      - name: Python tests Windows Systems
+        if: ${{ runner.os == 'windows' }}
+        shell: cmd /C call {0}
+        run: |
+          call C:\Users\runneradmin\micromamba-root\condabin\micromamba.bat activate xeus-cpp
+          cd test
+          pytest -sv test_xcpp_kernel.py 
 
       - name: Prepare code coverage report
         if: ${{ success() && (matrix.coverage == true) }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,30 +130,39 @@ function(configure_kernel kernel)
   set(XEUS_CPP_PATH "$ENV{PATH}")
   set(XEUS_CPP_LD_LIBRARY_PATH "$ENV{LD_LIBRARY_PATH}")
   set(XEUS_CPP_RESOURCE_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/clang/${CPPINTEROP_LLVM_VERSION_MAJOR})
+  set(XEUS_CPP_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
+
+  if (WIN32)
+    string(REPLACE "\\" "/" kernel "${kernel}")
+    string(REPLACE "\\" "/" XEUS_CPP_PATH "${XEUS_CPP_PATH}")
+    string(REPLACE "\\" "/" XEUS_CPP_LD_LIBRARY_PATH "${XEUS_CPP_LD_LIBRARY_PATH}")
+    string(REPLACE "\\" "/" XEUS_CPP_RESOURCE_DIR "${XEUS_CPP_RESOURCE_DIR}")
+    string(REPLACE "\\" "/" XEUS_CPP_INCLUDE_DIR "${XEUS_CPP_INCLUDE_DIR}")
+  endif()
 
   configure_file (
-    "${CMAKE_CURRENT_SOURCE_DIR}/${kernel}/kernel.json.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/${kernel}/kernel.json")
+    "${CMAKE_CURRENT_SOURCE_DIR}${kernel}kernel.json.in"
+    "${CMAKE_CURRENT_BINARY_DIR}${kernel}kernel.json")
 
   configure_file (
-    "${CMAKE_CURRENT_SOURCE_DIR}/${kernel}/logo-32x32.png"
-    "${CMAKE_CURRENT_BINARY_DIR}/${kernel}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}${kernel}logo-32x32.png"
+    "${CMAKE_CURRENT_BINARY_DIR}${kernel}"
     COPYONLY)
   configure_file (
-    "${CMAKE_CURRENT_SOURCE_DIR}/${kernel}/logo-64x64.png"
-    "${CMAKE_CURRENT_BINARY_DIR}/${kernel}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}${kernel}logo-64x64.png"
+    "${CMAKE_CURRENT_BINARY_DIR}${kernel}"
     COPYONLY)
   configure_file (
-    "${CMAKE_CURRENT_SOURCE_DIR}/${kernel}/logo-svg.svg"
-    "${CMAKE_CURRENT_BINARY_DIR}/${kernel}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}${kernel}logo-svg.svg"
+    "${CMAKE_CURRENT_BINARY_DIR}${kernel}"
     COPYONLY)
 endfunction()
 
 message("Configure kernels: ...")
-configure_kernel("share/jupyter/kernels/xcpp11")
-configure_kernel("share/jupyter/kernels/xcpp14")
-configure_kernel("share/jupyter/kernels/xcpp17")
-configure_kernel("share/jupyter/kernels/xcpp20")
+configure_kernel("/share/jupyter/kernels/xcpp11/")
+configure_kernel("/share/jupyter/kernels/xcpp14/")
+configure_kernel("/share/jupyter/kernels/xcpp17/")
+configure_kernel("/share/jupyter/kernels/xcpp20/")
 
 # Source files
 # ============

--- a/share/jupyter/kernels/xcpp11/kernel.json.in
+++ b/share/jupyter/kernels/xcpp11/kernel.json.in
@@ -9,6 +9,7 @@
       "-f",
       "{connection_file}",
       "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
+      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++11"@XEUS_CPP_OMP@
   ],
   "language": "cpp",

--- a/share/jupyter/kernels/xcpp14/kernel.json.in
+++ b/share/jupyter/kernels/xcpp14/kernel.json.in
@@ -9,7 +9,7 @@
       "-f",
       "{connection_file}",
       "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
-      "-I", "@CMAKE_INSTALL_PREFIX@/include",
+      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++14",
       "-fno-exceptions",
       "-O2",

--- a/share/jupyter/kernels/xcpp17-omp/kernel.json.in
+++ b/share/jupyter/kernels/xcpp17-omp/kernel.json.in
@@ -9,7 +9,7 @@
       "-f",
       "{connection_file}",
       "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
-      "-I", "@CMAKE_INSTALL_PREFIX@/include",
+      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++17"@XEUS_CPP_OMP@
   ],
   "language": "cpp",

--- a/share/jupyter/kernels/xcpp17/kernel.json.in
+++ b/share/jupyter/kernels/xcpp17/kernel.json.in
@@ -9,7 +9,7 @@
       "-f",
       "{connection_file}",
       "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
-      "-I", "@CMAKE_INSTALL_PREFIX@/include",
+      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++17"@XEUS_CPP_OMP@
   ],
   "language": "cpp",

--- a/share/jupyter/kernels/xcpp20/kernel.json.in
+++ b/share/jupyter/kernels/xcpp20/kernel.json.in
@@ -9,7 +9,7 @@
       "-f",
       "{connection_file}",
       "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
-      "-I", "@CMAKE_INSTALL_PREFIX@/include",
+      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++20"@XEUS_CPP_OMP@
   ],
   "language": "cpp",

--- a/test/test_xcpp_kernel.py
+++ b/test/test_xcpp_kernel.py
@@ -34,7 +34,10 @@ class XCppCompleteTests(jupyter_kernel_test.KernelTests):
         reply = self.get_non_kernel_info_reply(timeout=1)
         assert reply is not None
         self.assertEqual(reply["msg_type"], "complete_reply")
-        self.assertEqual(str(reply["content"]["matches"]), "['float', 'foo']")
+        if platform.system() == 'Windows':
+            self.assertEqual(str(reply["content"]["matches"]), "['fabs', 'fabsf', 'fabsl', 'float', 'foo']")
+        else:
+            self.assertEqual(str(reply["content"]["matches"]), "['float', 'foo']")
         self.assertEqual(reply["content"]["status"], "ok")
 
     # Continuation
@@ -64,69 +67,70 @@ class XCppCompleteTests(jupyter_kernel_test.KernelTests):
         self.assertEqual(reply["content"]["status"], "complete")
 
 
-class XCppTests(jupyter_kernel_test.KernelTests):
+if platform.system() != 'Windows':
+    class XCppTests(jupyter_kernel_test.KernelTests):
 
-    kernel_name = 'xcpp20'
+        kernel_name = 'xcpp20'
 
-    # language_info.name in a kernel_info_reply should match this
-    language_name = 'C++'
+        # language_info.name in a kernel_info_reply should match this
+        language_name = 'C++'
 
-    # Code that should write the exact string `hello, world` to STDOUT
-    code_hello_world = '#include <iostream>\nstd::cout << "hello, world" << std::endl;'
+        # Code that should write the exact string `hello, world` to STDOUT
+        code_hello_world = '#include <iostream>\nstd::cout << "hello, world" << std::endl;'
 
-    # Code that should cause (any) text to be written to STDERR
-    code_stderr = '#include <iostream>\nstd::cerr << "oops" << std::endl;'
+        # Code that should cause (any) text to be written to STDERR
+        code_stderr = '#include <iostream>\nstd::cerr << "oops" << std::endl;'
 
-    # Pager: code that should display something (anything) in the pager
-    code_page_something = "?std::vector"
+        # Pager: code that should display something (anything) in the pager
+        code_page_something = "?std::vector"
 
-    # Exception throwing
-    # TODO: Remove 'if' when test work on MacOS/arm64. Throw Exceptions make
-    # kernel/test non-workable.
-    ###code_generate_error = 'throw std::runtime_error("Unknown exception");' if platform.system() != "Darwin" or platform.processor() != 'arm' else ''
+        # Exception throwing
+        # TODO: Remove 'if' when test work on MacOS/arm64. Throw Exceptions make
+        # kernel/test non-workable.
+        ###code_generate_error = 'throw std::runtime_error("Unknown exception");' if platform.system() != "Darwin" or platform.processor() != 'arm' else ''
 
-    # Samples of code which generate a result value (ie, some text
-    # displayed as Out[n])
-    #code_execute_result = [
-    #    {
-    #        'code': '6 * 7',
-    #        'result': '42'
-    #    }
-    #]
+        # Samples of code which generate a result value (ie, some text
+        # displayed as Out[n])
+        #code_execute_result = [
+        #    {
+        #        'code': '6 * 7',
+        #        'result': '42'
+        #    }
+        #]
 
-    # Samples of code which should generate a rich display output, and
-    # the expected MIME type
-    code_display_data = [
-        {
-            'code': '#include <string>\n#include "xcpp/xdisplay.hpp"\nstd::string test("foobar");\nxcpp::display(test);',
-            'mime': 'text/plain'
-        },
-        {
-            'code': """
-#include <string>
-#include <fstream>
-#include "nlohmann/json.hpp"
-#include "xtl/xbase64.hpp"
-namespace im {
-  struct image {
-    inline image(const std::string& filename) {
-      std::ifstream fin(filename, std::ios::binary);
-      m_buffer << fin.rdbuf();
-    }
-    std::stringstream m_buffer;
-  };
-  nlohmann::json mime_bundle_repr(const image& i) {
-    auto bundle = nlohmann::json::object();
-    bundle["image/png"] = xtl::base64encode(i.m_buffer.str());
-    return bundle;
-  }
-}
-#include "xcpp/xdisplay.hpp"
-im::image marie("../notebooks/images/marie.png");
-xcpp::display(marie);""",
-            'mime': 'image/png'
+        # Samples of code which should generate a rich display output, and
+        # the expected MIME type
+        code_display_data = [
+            {
+                'code': '#include <string>\n#include "xcpp/xdisplay.hpp"\nstd::string test("foobar");\nxcpp::display(test);',
+                'mime': 'text/plain'
+            },
+            {
+                'code': """
+    #include <string>
+    #include <fstream>
+    #include "nlohmann/json.hpp"
+    #include "xtl/xbase64.hpp"
+    namespace im {
+      struct image {
+        inline image(const std::string& filename) {
+          std::ifstream fin(filename, std::ios::binary);
+          m_buffer << fin.rdbuf();
         }
-    ]
+        std::stringstream m_buffer;
+      };
+      nlohmann::json mime_bundle_repr(const image& i) {
+        auto bundle = nlohmann::json::object();
+        bundle["image/png"] = xtl::base64encode(i.m_buffer.str());
+        return bundle;
+      }
+    }
+    #include "xcpp/xdisplay.hpp"
+    im::image marie("../notebooks/images/marie.png");
+    xcpp::display(marie);""",
+                'mime': 'image/png'
+            }
+        ]
 
 
 class XCppTests2(jupyter_kernel_test.KernelTests):


### PR DESCRIPTION
This PR is a copy of https://github.com/compiler-research/xeus-cpp/pull/92 , but as one commit, as I was unable to squash the commits on the other PR.  It makes changes such that the kernels can be parsed on Windows for jupyter_kernel_test , so they can now run. I have stopped the failing tests from running on Windows. @vgvassilev @alexander-penev @JohanMabille can one of you review this PR?