### PR TITLE
Update testing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,10 @@ micromamba activate xeus-cpp
 You are now in a position to install xeus-cpp into this envirnoment. You can do this by executing
 
 ```bash
-mkdir build && cd build
+mkdir build
+cd build
 cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_PREFIX_PATH=$CONDA_PREFIX -D CMAKE_INSTALL_PREFIX=$CONDA_PREFIX -D CMAKE_INSTALL_LIBDIR=lib ..
-make install
+make
 ```
 
 To check that everything is installed correctly you can run the c++ tests by executing the following
@@ -55,4 +56,9 @@ and the python tests by executing
 ```bash
 cd ./test
 pytest -sv .
+```
+Once the build is passing all the tests you can install it by executing the following from the test folder
+```bash 
+cd ..
+make install
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 `xeus-cpp` is a Jupyter kernel for cpp based on the native implementation of the
 Jupyter protocol [xeus](https://github.com/jupyter-xeus/xeus).
 
-## Installation within a mamba envirnoment
+## Installation within a mamba envirnoment (non wasm build instructions)
 
 To ensure that the installation works, it is preferable to install `xeus-cpp` in a
 fresh environment. It is also needed to use a
@@ -40,9 +40,24 @@ mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.2 cppzmq x
 ```
 Now you can compile the kernel from the source by executing (replace `$CONDA_PREFIX` with a custom installation prefix if need be)
 ```bash
-mkdir build && cd build
+mkdir build
+cd build
 cmake .. -D CMAKE_PREFIX_PATH=$CONDA_PREFIX -D CMAKE_INSTALL_PREFIX=$CONDA_PREFIX -D CMAKE_INSTALL_LIBDIR=lib
-make && make install
+make
+```
+To test the build you execute the following to test the C++ tests
+```bash
+cd test
+./test_xeus_cpp
+```
+and
+```bash
+pytest -sv .
+```
+to perform the python tests. Once the build is passing all the tests you can install it by executing the following from the test folder
+```bash 
+cd ..
+make install
 ```
 
 ## Trying it online

--- a/docs/source/debug.rst
+++ b/docs/source/debug.rst
@@ -8,7 +8,7 @@ These steps are performed using the GNU Debugger (GDB), so ensure it is installe
 
 .. code-block:: bash
 
-    cmake -D CMAKE_BUILD_TYPE=Debug ..
+    cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_PREFIX_PATH=$CONDA_PREFIX -D CMAKE_INSTALL_PREFIX=$CONDA_PREFIX -D CMAKE_INSTALL_LIBDIR=lib ..
 
 In the same folder, run the command and copy the JSON displayed in the terminal.
 
@@ -32,4 +32,7 @@ Open a new terminal, navigate to the build directory, and run GDB to start debug
 Testing
 ========================
 
-The testing code for the source files is located in `test/test_interpreter.cpp`. Write the necessary tests and build the project as described in the repository's README or contributing guidelines. Then, execute `build/test/test_xeus_cpp` to verify if the tests were successful.
+The source code for the c++ tests is located in `test/test_interpreter.cpp`. The source code for the python tests is located in `test/test_xcpp_kernel.py`.
+Write the necessary tests and build the project as described in the repository's README or contributing guidelines. 
+Then, execute `build/test/test_xeus_cpp` from the top level directory to verify if the c++ tests were successful,
+and `pytest -sv build/test/test_xcpp_kernel.py` to execute the python tests.


### PR DESCRIPTION
This updates various files so they all contain the instructions to test the kernel. I also change it so its obvious that the build instructions are currently for the non wasm build. A PR to follow will add instructions on how to wasm build instructions.