### PR TITLE
Remove resource and include directories from kernel json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,15 +134,11 @@ endif ()
 function(configure_kernel kernel)
   set(XEUS_CPP_PATH "$ENV{PATH}")
   set(XEUS_CPP_LD_LIBRARY_PATH "$ENV{LD_LIBRARY_PATH}")
-  set(XEUS_CPP_RESOURCE_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/clang/${CPPINTEROP_LLVM_VERSION_MAJOR})
-  set(XEUS_CPP_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
 
   if (WIN32)
     string(REPLACE "\\" "/" kernel "${kernel}")
     string(REPLACE "\\" "/" XEUS_CPP_PATH "${XEUS_CPP_PATH}")
     string(REPLACE "\\" "/" XEUS_CPP_LD_LIBRARY_PATH "${XEUS_CPP_LD_LIBRARY_PATH}")
-    string(REPLACE "\\" "/" XEUS_CPP_RESOURCE_DIR "${XEUS_CPP_RESOURCE_DIR}")
-    string(REPLACE "\\" "/" XEUS_CPP_INCLUDE_DIR "${XEUS_CPP_INCLUDE_DIR}")
   endif()
 
   configure_file (

--- a/share/jupyter/kernels/xcpp11/kernel.json.in
+++ b/share/jupyter/kernels/xcpp11/kernel.json.in
@@ -8,8 +8,6 @@
       "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
       "-f",
       "{connection_file}",
-      "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
-      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++11"@XEUS_CPP_OMP@
   ],
   "language": "cpp",

--- a/share/jupyter/kernels/xcpp14/kernel.json.in
+++ b/share/jupyter/kernels/xcpp14/kernel.json.in
@@ -8,8 +8,6 @@
       "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
       "-f",
       "{connection_file}",
-      "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
-      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++14",
       "-fno-exceptions",
       "-O2",

--- a/share/jupyter/kernels/xcpp17-omp/kernel.json.in
+++ b/share/jupyter/kernels/xcpp17-omp/kernel.json.in
@@ -8,8 +8,6 @@
       "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
       "-f",
       "{connection_file}",
-      "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
-      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++17"@XEUS_CPP_OMP@
   ],
   "language": "cpp",

--- a/share/jupyter/kernels/xcpp17/kernel.json.in
+++ b/share/jupyter/kernels/xcpp17/kernel.json.in
@@ -8,8 +8,6 @@
       "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
       "-f",
       "{connection_file}",
-      "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
-      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++17"@XEUS_CPP_OMP@
   ],
   "language": "cpp",

--- a/share/jupyter/kernels/xcpp20/kernel.json.in
+++ b/share/jupyter/kernels/xcpp20/kernel.json.in
@@ -8,8 +8,6 @@
       "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
       "-f",
       "{connection_file}",
-      "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
-      "-I", "@XEUS_CPP_INCLUDE_DIR@",
       "-std=c++20"@XEUS_CPP_OMP@
   ],
   "language": "cpp",


### PR DESCRIPTION
When creating the interpreter we already detect and add the arguments for the resource and include directories here
https://github.com/mcbarton/xeus-cpp/blob/b58b15b83b27fe2e73c00c469346eea65301464d/src/xinterpreter.cpp#L37C1-L56C2 . This makes their addition in the kernel json file redundant.