### PR TITLE
Update available C++ kernels in documentation

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -7,7 +7,7 @@ on Jupyter kernels.
 
 1. Install the xeus-cpp from source using conda-forge for fetching dependencies.
 
-2. Launch the Jupyter Notebook with C++-11, C++-14, C++-17 kernels available.
+2. Launch the Jupyter Notebook with either the C++17 or C++20 kernel available.
 
 3. In a code cell, write the C++ code.
 


### PR DESCRIPTION
Recently we added a C++20 kernel and removed the C++11 and C++14 kernels. This PR updates the documentation to reflect this.