### PR TITLE
Remove reference to Python in documentation

### DIFF
--- a/docs/source/UsingXeus-Cpp.rst
+++ b/docs/source/UsingXeus-Cpp.rst
@@ -4,8 +4,3 @@ Using xeus-cpp
 - With xeus-cpp, you can write and execute C++ code interactively, seeing
   the results immediately. This REPL nature allows you to iterate quickly
   without the overhead of compiling and running separate C++ programs.
-
-- To achieve C++ and Python integration within a Jupyter environment we can use
-  xeus-cpp. Thereby you can write and execute C++ code interactively in
-  this environment.
-


### PR DESCRIPTION
Currently we do not have Python integration in the xeus-cpp kernel as far as I am aware (I read a comment it may be integrated by a plugin, but I forget where). This PR removes reference to Python in the documentation until it is integrated.