### PR TITLE
Update clang format spec to c++17 standard

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -73,6 +73,6 @@ SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: c++14
+Standard: c++17
 TabWidth: '4'
 UseTab: Never


### PR DESCRIPTION
We have the C++ standard in cmake set to c++17 but in the clang format spec its set to c++14 for some reason. This PR just updates the spec to the correct one.