### PR TITLE
Remove reference to Fortran module references in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,6 @@
 *.dylib
 *.dll
 
-# Fortran module files
-*.mod
-*.smod
-
 # Compiled Static libraries
 *.lai
 *.la


### PR DESCRIPTION
For some reason we have references to Fortran module files in the README. This PR removes them as unneeded.