### PR TITLE
Make cmake minimum version same accross repo

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@
 # Unit tests
 # ==========
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.24)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xeus-cpp-test)


### PR DESCRIPTION
Currently cmake minimum version in the test folder is older than the one for the main repo. This updates it to have the same minimum.