### PR TITLE
doc: Fix micromamba development environment creation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ or miniconda installed cd into the xeus-cpp directory and set setup your environ
 
 ```bash
 cd xeus-cpp
-micromamba create -n xeus-cpp -f environment-dev.yml
+micromamba create -f environment-dev.yml -y
 micromamba activate xeus-cpp
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ or miniconda installed cd into the xeus-cpp directory and set setup your environ
 
 ```bash
 cd xeus-cpp
-micromamba create -n xeus-cpp environment-dev.yml
+micromamba create -n xeus-cpp -f environment-dev.yml
 micromamba activate xeus-cpp
 ```
 


### PR DESCRIPTION
# Description

Following the development environment creation command in `CONTRIBUTING.md` using `micromamba` gives the following error:

```bash
╭─okabe@basu ~/open-source/xeus-cpp ‹fix-build-instruction› 
╰─$ micromamba create -n xeus-cpp environment-dev.yml   
conda-forge/linux-64                                        Using cache
conda-forge/noarch                                          Using cache
nodefaults/linux-64                                           No change
nodefaults/noarch                                             No change
error    libmamba Could not solve for environment specs
    The following package could not be installed
    └─ environment-dev.yml does not exist (perhaps a typo or a missing channel).
critical libmamba Could not solve for environment specs
```

The command should be updated to use the `-f` to use the `environment-dev.yml` file.

Fixes # (issue)
N/A

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [x] Required documentation updates
