### PR TITLE
Added functions to retrieve tag files/configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ set(XCPP_TAGCONFS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/etc/xeus-cpp/tags.d)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/xeus-cpp/xeus_cpp_config.hpp.in" 
                 "${CMAKE_CURRENT_SOURCE_DIR}/include/xeus-cpp/xeus_cpp_config.hpp")
 
+file(COPY "${XCPP_TAGFILES_DIR}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/share/xeus-cpp")
+file(COPY "${XCPP_TAGCONFS_DIR}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/etc/xeus-cpp")
+
 # Versionning
 # ===========
 

--- a/include/xeus-cpp/xutils.hpp
+++ b/include/xeus-cpp/xutils.hpp
@@ -32,6 +32,12 @@ namespace xcpp
 
     XEUS_CPP_API
     interpreter_ptr build_interpreter(int argc, char** argv);
+
+    XEUS_CPP_API
+    std::string retrieve_tagconf_dir();
+
+    XEUS_CPP_API
+    std::string retrieve_tagfile_dir();
 }
 
 #endif

--- a/src/xinspect.hpp
+++ b/src/xinspect.hpp
@@ -17,6 +17,7 @@
 
 #include "xeus-cpp/xbuffer.hpp"
 #include "xeus-cpp/xpreamble.hpp"
+#include "xeus-cpp/xutils.hpp"
 
 #include "xdemangle.hpp"
 #include "xparser.hpp"
@@ -122,8 +123,8 @@ namespace xcpp
 
     void inspect(const std::string& code, nl::json& kernel_res)
     {
-        std::string tagconf_dir = XCPP_TAGCONFS_DIR;
-        std::string tagfiles_dir = XCPP_TAGFILES_DIR;
+        std::string tagconf_dir = retrieve_tagconf_dir();
+        std::string tagfiles_dir = retrieve_tagfile_dir();
 
         nl::json tagconfs = read_tagconfs(tagconf_dir.c_str());
 

--- a/src/xutils.cpp
+++ b/src/xutils.cpp
@@ -106,11 +106,11 @@ namespace xcpp
 
         std::string prefix = xeus::prefix_path();
 
-        #if defined (_WIN32)
-            const char separator = '\\';
-        #else
-            const char separator = '/';
-        #endif
+#if defined(_WIN32)
+        const char separator = '\\';
+#else
+        const char separator = '/';
+#endif
 
         return prefix + separator + "etc" + separator + "xeus-cpp" + separator + "tags.d";
     }
@@ -125,11 +125,11 @@ namespace xcpp
 
         std::string prefix = xeus::prefix_path();
 
-        #if defined (_WIN32)
-            const char separator = '\\';
-        #else
-            const char separator = '/';
-        #endif
+#if defined(_WIN32)
+        const char separator = '\\';
+#else
+        const char separator = '/';
+#endif
 
         return prefix + separator + "share" + separator + "xeus-cpp" + separator + "tagfiles";
     }

--- a/src/xutils.cpp
+++ b/src/xutils.cpp
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #endif
 
+#include "xeus/xsystem.hpp"
 
 #include "xeus-cpp/xutils.hpp"
 #include "xeus-cpp/xinterpreter.hpp"
@@ -95,4 +96,41 @@ namespace xcpp
         return interp_ptr;
     }
 
+    std::string retrieve_tagconf_dir()
+    {
+        const char* tagconf_dir_env = std::getenv("XCPP_TAGCONFS_DIR");
+        if (tagconf_dir_env != nullptr)
+        {
+            return tagconf_dir_env;
+        }
+
+        std::string prefix = xeus::prefix_path();
+
+        #if defined (_WIN32)
+            const char separator = '\\';
+        #else
+            const char separator = '/';
+        #endif
+
+        return prefix + separator + "etc" + separator + "xeus-cpp" + separator + "tags.d";
+    }
+
+    std::string retrieve_tagfile_dir()
+    {
+        const char* tagfile_dir_env = std::getenv("XCPP_TAGFILES_DIR");
+        if (tagfile_dir_env != nullptr)
+        {
+            return tagfile_dir_env;
+        }
+
+        std::string prefix = xeus::prefix_path();
+
+        #if defined (_WIN32)
+            const char separator = '\\';
+        #else
+            const char separator = '/';
+        #endif
+
+        return prefix + separator + "share" + separator + "xeus-cpp" + separator + "tagfiles";
+    }
 }


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.
We should be dependent on compile time definitions for fetching tagfiles and we should be using prefix_path from xeus to do the following at runtime as mentioned in the issue. Hence I've added relevant functions in the xutils.hpp file for the same.

Fixes #54 

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
