### PR TITLE
Add example notebooks + readme.md to Jupyter Lite demo

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -86,7 +86,9 @@ jobs:
           micromamba create -n xeus-lite-host jupyterlite-core
           micromamba activate xeus-lite-host
           python -m pip install jupyterlite-xeus
-          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents README.md --output-dir dist
+          mv $GITHUB_WORKSPACE/notebooks dist
+          mv $GITHUB_WORKSPACE/README.md dist
+          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --output-dir dist
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

After the Jupyter Lite xeus-cpp demo sucessfully deployed as a Github page I realised that the demo was missing the example notebook and README.md . @vgvassilev @anutosh491 can one of you merge this PR to add these to the demo?

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
