### PR TITLE
Add example notebook and readme to files folder inside dist

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -86,9 +86,10 @@ jobs:
           micromamba create -n xeus-lite-host jupyterlite-core
           micromamba activate xeus-lite-host
           python -m pip install jupyterlite-xeus
-          mv $GITHUB_WORKSPACE/notebooks dist
-          mv $GITHUB_WORKSPACE/README.md dist
           jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --output-dir dist
+          mkdir -p dist/files
+          mv notebooks dist/files
+          mv README.md dist/files
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

@vgvassilev @anutosh491 Currently the example notebook and readme.md is not showing up in the Jupyter Lite demo. Based on the fact that the files for the jupyter lite xeus-python demo are in a folder called files (see https://jupyterlite.github.io/xeus-python-demo/files/README.md) I have modified the ci  to make this folder in the build folder dist (if not present already), and them move the files we need into the folder accordingly to try and fix the problem we are having. 

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
