### PR TITLE
Removed dependency on cppzmq

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ source activate  "xeus-cpp"
 ```
 We will now install the dependencies needed to compile xeux-cpp from source within this environment by executing the following
 ```bash
-mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.2 cppzmq xtl jupyterlab CppInterOp cpp-argparse<3.1 pugixml doctest -c conda-forge
+mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.3 jupyterlab CppInterOp cpp-argparse<3.1 pugixml doctest -c conda-forge
 ```
 Now you can compile the kernel from the source by executing (replace `$CONDA_PREFIX` with a custom installation prefix if need be)
 ```bash
@@ -135,16 +135,15 @@ http://xeus-cpp.readthedocs.io
 
 - [xeus-zmq](https://github.com/jupyter-xeus/xeus-zmq)
 - [nlohmann_json](https://github.com/nlohmann/json)
-- [cppzmq](https://github.com/zeromq/cppzmq)
 - [argparse](https://github.com/p-ranav/argparse)
 - [CppInterOp](https://github.com/compiler-research/CppInterOp)
 
-| `xeus-cpp` | `xeus-zmq`      | `CppInterOp` | `pugixml` | `cppzmq` | `cpp-argparse`| `nlohmann_json` |
-|------------|-----------------|--------------|-----------|----------|---------------|-----------------|
-|  main      |  >=3.0.0,<4.0.0 | >=1.3.0      | ~1.8.1    | ~4.3.0   | <3.1          | >=3.11.3,<4.0   |
-|  0.5.0     |  >=3.0.0,<4.0.0 | >=1.3.0      | ~1.8.1    | ~4.3.0   | <3.1          | >=3.11.3,<4.0   |
+| `xeus-cpp` | `xeus-zmq`      | `CppInterOp` | `pugixml` | `cpp-argparse`| `nlohmann_json` |
+|------------|-----------------|--------------|-----------|---------------|-----------------|
+|  main      |  >=3.0.0,<4.0.0 | >=1.3.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
+|  0.5.0     |  >=3.0.0,<4.0.0 | >=1.3.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
 
-Versions prior to `0.5.0` have an additional dependency on [xtl](https://github.com/xtensor-stack/xtl) & [clang](https://github.com/llvm/llvm-project/).
+Versions prior to `0.5.0` have an additional dependency on [xtl](https://github.com/xtensor-stack/xtl), [clang](https://github.com/llvm/llvm-project/) & [cppzmq](https://github.com/zeromq/cppzmq)
 
 | `xeus-cpp` | `xeus-zmq`      | `xtl`           | `clang`   | `pugixml` | `cppzmq` | `cpp-argparse`| `nlohmann_json` |
 |------------|-----------------|-----------------|-----------|-----------|----------|---------------|-----------------|

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -29,8 +29,8 @@ this environment by executing the following
 
 .. code-block:: bash
 
-    mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.2 cppzmq 
-    xtl jupyterlab CppInterOp cpp-argparse<3.1 pugixml doctest -c conda-forge
+    mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.3
+    jupyterlab CppInterOp cpp-argparse<3.1 pugixml doctest -c conda-forge
 
 Now you can compile the kernel from the source by executing (replace `$CONDA_PREFIX` 
 with a custom installation prefix if need be)

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,6 @@ dependencies:
   - xeus>=5.0.0
   - xeus-zmq>=3.0,<4.0
   - nlohmann_json=3.11.3
-  - cppzmq
   - CppInterOp>=1.3.0
   - pugixml
   - cpp-argparse <3.1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,6 @@ int main(int argc, char* argv[])
 
     interpreter_ptr interpreter = xcpp::build_interpreter(argc, argv);
 
-    // auto context = xeus::make_context<zmq::context_t>();
     std::unique_ptr<xeus::xcontext> context = xeus::make_zmq_context();
 
     if (!file_name.empty())

--- a/xeus-cppConfig.cmake.in
+++ b/xeus-cppConfig.cmake.in
@@ -22,8 +22,6 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
 
 include(CMakeFindDependencyMacro)
 find_dependency(xeus-zmq @xeus-zmq_REQUIRED_VERSION@)
-find_dependency(cppzmq @cppzmq_REQUIRED_VERSION@)
-
 
 if (NOT TARGET xeus-cpp AND NOT TARGET xeus-cpp-static)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
# Description

After updating to xeus 5, I think we can drop cppzmq as a dependency

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Added/removed dependencies
- [x] Required documentation updates
