### PR TITLE
Update to use CppInterOp 1.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (NOT TARGET xeus AND NOT TARGET xeus-static)
     endif()
 endif ()
 
-set(CppInterOp_REQUIRED_VERSION 1.3.0)
+set(CppInterOp_REQUIRED_VERSION 1.4.0)
 
 # Flags
 # =====

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ http://xeus-cpp.readthedocs.io
 
 | `xeus-cpp` | `xeus-zmq`      | `CppInterOp` | `pugixml` | `cpp-argparse`| `nlohmann_json` |
 |------------|-----------------|--------------|-----------|---------------|-----------------|
-|  main      |  >=3.0.0,<4.0.0 | >=1.3.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
+|  main      |  >=3.0.0,<4.0.0 | >=1.4.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
 |  0.5.0     |  >=3.0.0,<4.0.0 | >=1.3.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
 
 Versions prior to `0.5.0` have an additional dependency on [xtl](https://github.com/xtensor-stack/xtl), [clang](https://github.com/llvm/llvm-project/) & [cppzmq](https://github.com/zeromq/cppzmq)

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - xeus>=5.0.0
   - xeus-zmq>=3.0,<4.0
   - nlohmann_json=3.11.3
-  - CppInterOp>=1.3.0
+  - CppInterOp>=1.4.0
   - pugixml
   - cpp-argparse <3.1
   - zlib

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -6,6 +6,6 @@ dependencies:
   - nlohmann_json
   - xeus-lite
   - xeus
-  - CppInterOp>=1.3.0
+  - CppInterOp>=1.4.0
   - cpp-argparse
   - pugixml


### PR DESCRIPTION
# Description

Now that cppinterop 1.4.0 is available on conda-forge and emscripten-forge, this PR tries to update xeus-cpp to use the latest version. The new release (0.6.0) for xeus-cpp should be made using that version hopefully

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Added/removed dependencies
- [ ] Required documentation updates
