### PR TITLE
Minor: add string quotes in command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ source activate  "xeus-cpp"
 ```
 We will now install the dependencies needed to compile xeux-cpp from source within this environment by executing the following
 ```bash
-mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.3 jupyterlab CppInterOp cpp-argparse<3.1 pugixml doctest -c conda-forge
+mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.3 jupyterlab CppInterOp cpp-argparse"<3.1" pugixml doctest -c conda-forge
 ```
 Now you can compile the kernel from the source by executing (replace `$CONDA_PREFIX` with a custom installation prefix if need be)
 ```bash


### PR DESCRIPTION
# Description

On Rocky 8 linux on bash -
```
±|main|→ mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.3 jupyterlab CppInterOp cpp-argparse<3.1 pugixml doctest -c conda-forge
bash: 3.1: No such file or directory
```
As far as I know, bash interprets < as a redirection operator. Now it will work with all terminals.

## Type of change

Please tick all options which are relevant.
- [x] Required documentation updates
