### PR TITLE
Fix logic for resource dir flag

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -37,12 +37,13 @@ using Args = std::vector<const char*>;
 
 void* createInterpreter(const Args &ExtraArgs = {}) {
   Args ClangArgs = {/*"-xc++"*/"-v"}; // ? {"-Xclang", "-emit-llvm-only", "-Xclang", "-diagnostic-log-file", "-Xclang", "-", "-xc++"};
-  if (std::find(ExtraArgs.begin(), ExtraArgs.end(), "-resource-dir") == ExtraArgs.end()) {
-    std::string resource_dir = Cpp::DetectResourceDir();
-    if (resource_dir.empty())
-      std::cerr << "Failed to detect the resource-dir\n";
-    ClangArgs.push_back("-resource-dir");
-    ClangArgs.push_back(resource_dir.c_str());
+  if (std::find(ExtraArgs.begin(), ExtraArgs.end(), "-resource-dir") == ExtraArgs.end())
+  {
+      std::string resource_dir = Cpp::DetectResourceDir();
+      if (resource_dir.empty())
+          std::cerr << "Failed to detect the resource-dir\n";
+      ClangArgs.push_back("-resource-dir");
+      ClangArgs.push_back(resource_dir.c_str());
   }
   std::vector<std::string> CxxSystemIncludes;
   Cpp::DetectSystemCompilerIncludePaths(CxxSystemIncludes);

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -37,12 +37,14 @@ using Args = std::vector<const char*>;
 
 void* createInterpreter(const Args &ExtraArgs = {}) {
   Args ClangArgs = {/*"-xc++"*/"-v"}; // ? {"-Xclang", "-emit-llvm-only", "-Xclang", "-diagnostic-log-file", "-Xclang", "-", "-xc++"};
-  if (std::find(ExtraArgs.begin(), ExtraArgs.end(), "-resource-dir") != ExtraArgs.end()) {
+  if (std::find(ExtraArgs.begin(), ExtraArgs.end(), "-resource-dir") == ExtraArgs.end()) {
     std::string resource_dir = Cpp::DetectResourceDir();
-    if (resource_dir.empty())
-      std::cerr << "Failed to detect the resource-dir\n";
-    ClangArgs.push_back("-resource-dir");
-    ClangArgs.push_back(resource_dir.c_str());
+    if (!resource_dir.empty()) {
+        ClangArgs.push_back("-resource-dir");
+        ClangArgs.push_back(resource_dir.c_str());
+    } else {
+        std::cerr << "Failed to detect the resource-dir\n";
+    }
   }
   std::vector<std::string> CxxSystemIncludes;
   Cpp::DetectSystemCompilerIncludePaths(CxxSystemIncludes);

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -39,9 +39,8 @@ void* createInterpreter(const Args &ExtraArgs = {}) {
   Args ClangArgs = {/*"-xc++"*/"-v"}; // ? {"-Xclang", "-emit-llvm-only", "-Xclang", "-diagnostic-log-file", "-Xclang", "-", "-xc++"};
   if (std::find(ExtraArgs.begin(), ExtraArgs.end(), "-resource-dir") == ExtraArgs.end()) {
     std::string resource_dir = Cpp::DetectResourceDir();
-    if (resource_dir.empty()) {
-        std::cerr << "Failed to detect the resource-dir\n";
-    }
+    if (resource_dir.empty())
+      std::cerr << "Failed to detect the resource-dir\n";
     ClangArgs.push_back("-resource-dir");
     ClangArgs.push_back(resource_dir.c_str());
   }

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -41,7 +41,9 @@ void* createInterpreter(const Args &ExtraArgs = {}) {
   {
       std::string resource_dir = Cpp::DetectResourceDir();
       if (resource_dir.empty())
-          std::cerr << "Failed to detect the resource-dir\n";
+      {
+        std::cerr << "Failed to detect the resource-dir\n";
+      }
       ClangArgs.push_back("-resource-dir");
       ClangArgs.push_back(resource_dir.c_str());
   }

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -39,12 +39,11 @@ void* createInterpreter(const Args &ExtraArgs = {}) {
   Args ClangArgs = {/*"-xc++"*/"-v"}; // ? {"-Xclang", "-emit-llvm-only", "-Xclang", "-diagnostic-log-file", "-Xclang", "-", "-xc++"};
   if (std::find(ExtraArgs.begin(), ExtraArgs.end(), "-resource-dir") == ExtraArgs.end()) {
     std::string resource_dir = Cpp::DetectResourceDir();
-    if (!resource_dir.empty()) {
-        ClangArgs.push_back("-resource-dir");
-        ClangArgs.push_back(resource_dir.c_str());
-    } else {
+    if (resource_dir.empty()) {
         std::cerr << "Failed to detect the resource-dir\n";
     }
+    ClangArgs.push_back("-resource-dir");
+    ClangArgs.push_back(resource_dir.c_str());
   }
   std::vector<std::string> CxxSystemIncludes;
   Cpp::DetectSystemCompilerIncludePaths(CxxSystemIncludes);


### PR DESCRIPTION
The logic for the resource dir flag looks corrupt. 

I am guessing we need to check if the flag is available, if not we need CppInterOp to fetch it for us. If flag is found add the arguments else return error.