### PR TITLE
Fix logic for resource dir flag

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -37,7 +37,7 @@ using Args = std::vector<const char*>;
 
 void* createInterpreter(const Args &ExtraArgs = {}) {
   Args ClangArgs = {/*"-xc++"*/"-v"}; // ? {"-Xclang", "-emit-llvm-only", "-Xclang", "-diagnostic-log-file", "-Xclang", "-", "-xc++"};
-  if (std::find(ExtraArgs.begin(), ExtraArgs.end(), "-resource-dir") != ExtraArgs.end()) {
+  if (std::find(ExtraArgs.begin(), ExtraArgs.end(), "-resource-dir") == ExtraArgs.end()) {
     std::string resource_dir = Cpp::DetectResourceDir();
     if (resource_dir.empty())
       std::cerr << "Failed to detect the resource-dir\n";


### PR DESCRIPTION
The logic for the resource dir flag looks corrupt.

I am guessing we need to check if the flag is available, if not we need CppInterOp to fetch it for us. If flag is found add the arguments else return error.