### PR TITLE
Stop fetching emsdk from conda-forge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,19 +226,21 @@ jobs:
       - name: Setup emsdk
         shell: bash -l {0}
         run: |
-          emsdk install ${{matrix.emsdk_ver}}     
+          cd $HOME
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install  ${{ matrix.emsdk_ver }}
 
       - name: Build xeus-cpp
         shell: bash -l {0}
         run: |
-          emsdk activate ${{matrix.emsdk_ver}}
-          source $CONDA_EMSDK_DIR/emsdk_env.sh
+          $HOME/emsdk/emsdk activate ${{matrix.emsdk_ver}}
+          source $HOME/emsdk/emsdk_env.sh
           micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
           
           mkdir build
           pushd build
 
-          export EMPACK_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
           export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
           echo "PREFIX=$PREFIX" >> $GITHUB_ENV
           export CMAKE_PREFIX_PATH=$PREFIX

--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ micromamba activate xeus-cpp-wasm-build
 
 You'll now want to make sure you're using emsdk version "3.1.45" and activate it. You can get this by executing the following
 ```bash
-emsdk install 3.1.45
-emsdk activate 3.1.45
-source $CONDA_EMSDK_DIR/emsdk_env.sh
+cd $HOME
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install 3.1.45
+./emsdk activate 3.1.45
+source $HOME/emsdk/emsdk_env.sh
 ```
 
 You are now in a position to build the xeus-cpp kernel. You build it by executing the following
@@ -88,7 +91,6 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
 micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
 mkdir build
 pushd build
-export EMPACK_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
 export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
 export CMAKE_PREFIX_PATH=$PREFIX
 export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX

--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -3,5 +3,3 @@ channels:
   - conda-forge
 dependencies:
   - cmake
-  - emsdk >=3.1.11
-  - empack >=2.0.1


### PR DESCRIPTION
# Description

emsdk's recipe from conda-forge is no longer being maintained. Hence preferably we should clone it and install it accordingly.

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Added/removed dependencies
- [ ] Required documentation updates
