### PR TITLE
Fix finding Resource Dir

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -37,7 +37,11 @@ using Args = std::vector<const char*>;
 
 void* createInterpreter(const Args &ExtraArgs = {}) {
   Args ClangArgs = {/*"-xc++"*/"-v"}; // ? {"-Xclang", "-emit-llvm-only", "-Xclang", "-diagnostic-log-file", "-Xclang", "-", "-xc++"};
-  if (std::find(ExtraArgs.begin(), ExtraArgs.end(), "-resource-dir") == ExtraArgs.end()) {
+  auto it = std::find_if(ExtraArgs.begin(), ExtraArgs.end(), [](const char* arg) {
+    return std::strcmp(arg, "-resource-dir") == 0;
+  });
+
+  if (it == ExtraArgs.end()) {
     std::string resource_dir = Cpp::DetectResourceDir();
     if (resource_dir.empty())
       std::cerr << "Failed to detect the resource-dir\n";


### PR DESCRIPTION
# Description

`std::find `operates based on the o`perator==` of the type being compared. For `const char*`, the `operator== `compares the memory addresses (the pointer values), not the contents of the strings.

Hence although we should fetch resource dir from the kernel.json file, we end up entering the block checking for resource dir and trying getting it through CppInterOp. This should not be the case.


## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
