### PR TITLE
Skip computing resource dir and include paths for xeus-cpp-lite

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -28,6 +28,7 @@ using Args = std::vector<const char*>;
 
 void* createInterpreter(const Args &ExtraArgs = {}) {
   Args ClangArgs = {/*"-xc++"*/"-v"}; // ? {"-Xclang", "-emit-llvm-only", "-Xclang", "-diagnostic-log-file", "-Xclang", "-", "-xc++"};
+#ifndef EMSCRIPTEN
   if (std::find_if(ExtraArgs.begin(), ExtraArgs.end(), [](const std::string& s) {
     return s == "-resource-dir";}) == ExtraArgs.end()) {
     std::string resource_dir = Cpp::DetectResourceDir();
@@ -42,6 +43,7 @@ void* createInterpreter(const Args &ExtraArgs = {}) {
     ClangArgs.push_back("-isystem");
     ClangArgs.push_back(CxxInclude.c_str());
   }
+#endif
   ClangArgs.insert(ClangArgs.end(), ExtraArgs.begin(), ExtraArgs.end());
   // FIXME: We should process the kernel input options and conditionally pass
   // the gpu args here.
@@ -357,7 +359,9 @@ __get_cxx_version ()
 
     void interpreter::init_includes()
     {
+#ifndef EMSCRIPTEN
         Cpp::AddIncludePath((xeus::prefix_path() + "/include/").c_str());
+#endif
     }
 
     void interpreter::init_preamble()


### PR DESCRIPTION
While using xeus-cpp-lite ( or rather running clang-repl in the browser) , local paths to system includes or resource dirs don't make sense.

What should happen here is content out of 
1) Sysroot provided by emsdk (provided already)
2) Resource dir hopefully provided by CppInterOp (in the works)

Should be collected in one location and then we need to load it using emscripten's `--preload-file` ( we can use this flag only once as it creates a .data file which comprises of all the headers/file we need)

So 
1) The resource dir path present in the kernel.json is of no use
```
  "argv": [
      "/Users/anutosh491/micromamba/envs/xeus-cpp-wasm-host/bin/xcpp",
      "-f",
      "{connection_file}",
      "-resource-dir", "/Users/anutosh491/micromamba/envs/xeus-cpp-wasm-host/lib/clang/19",
      "-I", "/Users/anutosh491/micromamba/envs/xeus-cpp-wasm-host/include",
      "-std=c++20"
  ],
```
2) Using `DetectResourceDir` and  `DetectSystemCompilerIncludePaths` can't be done as both depend on `exec` (marked as won't fix on emscripten)

3) `Init_includes()` adds `/Users/anutosh491/micromamba/envs/xeus-cpp-wasm-host/include` to the cc1 command but this doesn't make sense either.

