### PR TITLE
Enhance Dynamic Include Path Management in xeus-cpp with XEUS_SEARCH_PATH Support

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -357,7 +357,25 @@ __get_cxx_version ()
 
     void interpreter::init_includes()
     {
+        // Add the standard include path
         Cpp::AddIncludePath((xeus::prefix_path() + "/include/").c_str());
+
+        // Add non-standard include paths from XEUS_SEARCH_PATH
+        const char* non_standard_paths = XEUS_SEARCH_PATH;
+
+        if (non_standard_paths && std::strlen(non_standard_paths) > 0)
+        {
+            // Split the paths by colon ':' and add each one
+            std::istringstream stream(non_standard_paths);
+            std::string path;
+            while (std::getline(stream, path, ':'))
+            {
+                if (!path.empty())
+                {
+                    Cpp::AddIncludePath(path.c_str());
+                }
+            }
+        }
     }
 
     void interpreter::init_preamble()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,3 +67,11 @@ target_link_libraries(test_xeus_cpp xeus-cpp doctest::doctest ${CMAKE_THREAD_LIB
 target_include_directories(test_xeus_cpp PRIVATE ${XEUS_CPP_INCLUDE_DIR})
 
 add_custom_target(xtest COMMAND test_xeus_cpp DEPENDS test_xeus_cpp)
+
+set(XEUS_SEARCH_PATH $<JOIN:$<TARGET_PROPERTY:xeus-cpp,INCLUDE_DIRECTORIES>,:>)
+
+if (NOT EMSCRIPTEN)
+    set(XEUS_SEARCH_PATH "${XEUS_SEARCH_PATH}:${CMAKE_CURRENT_SOURCE_DIR}/src")
+endif()
+
+target_compile_definitions(xeus-cpp PRIVATE "XEUS_SEARCH_PATH=\"${XEUS_SEARCH_PATH}\"")


### PR DESCRIPTION
# Description

This PR introduces improvements to the `xeus-cpp` library to handle dynamic include paths more effectively. It includes updates to the `interpreter::init_includes` function and the CMakeLists file. These changes aim to enhance flexibility and maintainability by leveraging the `XEUS_SEARCH_PATH` environment variable for managing include directories dynamically.

### **Key Changes**
1. **Updated `interpreter::init_includes` Function:**
   - Parses the `XEUS_SEARCH_PATH` environment variable to include non-standard directories.
   - Adds support for multiple include paths, separated by colons (`:`).

2. **Modified CMakeLists File:**
   - Dynamically builds the `XEUS_SEARCH_PATH` variable by joining target include directories.
   - Includes the `src` directory for non-EMSCRIPTEN builds.
   - Passes the `XEUS_SEARCH_PATH` as a preprocessor definition to the compiler.

These updates simplify the configuration and usage of custom include paths.

Fixes #175 

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature 
- [ ] Added/removed dependencies
- [ ] Required documentation updates


