### PR TITLE
Update clang-tidy-review action to v0.20.1

### DIFF
--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Post review comments
         id: post-review
-        uses: ZedThree/clang-tidy-review/post@v0.18.0
+        uses: ZedThree/clang-tidy-review/post@v0.20.1
         with:
           max_comments: 10
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -30,7 +30,7 @@ jobs:
           version: "17.0.6"
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.18.0
+        uses: ZedThree/clang-tidy-review@v0.20.1
         id: review
         with:
           build_dir: build
@@ -53,4 +53,4 @@ jobs:
             cmake . -B build -DCMAKE_C_COMPILER="$GITHUB_WORKSPACE/llvm/bin/clang" -DCMAKE_CXX_COMPILER="$GITHUB_WORKSPACE/llvm/bin/clang++" -DCMAKE_EXPORT_COMPILE_COMMANDS=On
             
       - name: Upload artifacts
-        uses: ZedThree/clang-tidy-review/upload@v0.18.0
+        uses: ZedThree/clang-tidy-review/upload@v0.20.1

--- a/src/xoptions.cpp
+++ b/src/xoptions.cpp
@@ -44,3 +44,4 @@ namespace xcpp
         }
     }
 }
+


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

The clang-tidy-review workflow is currently broken. This was fixed by upgrading to a newer version of the action in other repos.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
