### PR TITLE
Upgrade to use CppInterOp 1.5.0 minimum so that version should work for wasm builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ endif()
 
 set(xeus_REQUIRED_VERSION 5.0.0)
 set(xeus_zmq_REQUIRED_VERSION 3.0.0)
-set(CppInterOp_REQUIRED_VERSION 1.4.0)
+set(CppInterOp_REQUIRED_VERSION 1.5.0)
 
 if (NOT TARGET xeus AND NOT TARGET xeus-static)
     find_package(xeus ${xeus_REQUIRED_VERSION} REQUIRED)

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ http://xeus-cpp.readthedocs.io
 
 | `xeus-cpp` | `xeus-zmq`      | `CppInterOp` | `pugixml` | `cpp-argparse`| `nlohmann_json` |
 |------------|-----------------|--------------|-----------|---------------|-----------------|
-|  main      |  >=3.0.0,<4.0.0 | >=1.4.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
+|  main      |  >=3.0.0,<4.0.0 | >=1.5.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
 |  0.5.0     |  >=3.0.0,<4.0.0 | >=1.3.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
 
 Versions prior to `0.5.0` have an additional dependency on [xtl](https://github.com/xtensor-stack/xtl), [clang](https://github.com/llvm/llvm-project/) & [cppzmq](https://github.com/zeromq/cppzmq)

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - xeus>=5.0.0
   - xeus-zmq>=3.0,<4.0
   - nlohmann_json=3.11.3
-  - CppInterOp>=1.4.0
+  - CppInterOp>=1.5.0
   - pugixml
   - cpp-argparse <3.1
   - zlib

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -6,6 +6,6 @@ dependencies:
   - nlohmann_json
   - xeus-lite
   - xeus
-  - CppInterOp>=1.4.0
+  - CppInterOp>=1.5.0
   - cpp-argparse
   - pugixml


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR is ready for when the the CppInterOp version 1.5.0 occurs. Once it is release the ci should be rerun.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Added/removed dependencies
- [x] Required documentation updates
