### PR TITLE
Add Ubuntu 22.04 back to ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,9 @@ jobs:
             coverage: true
             extra_cmake_flags: -DCMAKE_BUILD_TYPE=Debug
             micromamba_shell_init: bash
+          - name: ubu22
+            os: ubuntu-22.04
+            micromamba_shell_init: bash
           - name: osx13-x86
             os: macos-13
             micromamba_shell_init: bash
@@ -186,6 +189,10 @@ jobs:
         include:
           - name: ubu24
             os: ubuntu-24.04
+            emsdk_ver: "3.1.45"
+            micromamba_shell_init: bash
+          - name: ubu22
+            os: ubuntu-22.04
             emsdk_ver: "3.1.45"
             micromamba_shell_init: bash
           - name: osx13-x86


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR adds back Ubuntu 22.04 to the ci. Seems unlikely that one Ubuntu would be broken, and another ok, but it does happen with some sometimes. This PR allows us to be certain it hasn't happened to xeus-cpp.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
