### PR TITLE
Address todo related to variables provided by cppinterop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,10 +103,7 @@ endif ()
 
 find_package(CppInterOp ${CppInterOp_REQUIRED_VERSION} REQUIRED)
 if(CppInterOp_FOUND)
-  message(STATUS "Found CppInterOp: compatible with Clang ${CPPINTEROP_LLVM_VERSION_MAJOR}.x")
-  # TODO : Fix after variables are set correctly
-  # Check https://github.com/compiler-research/CppInterOp/pull/336
-  # message(STATUS "Found CppInterOp: config=${CPPINTEROP_CONFIG} dir=${CPPINTEROP_DIR} (found version=${CPPINTEROP_VERSION} compatible with Clang ${CPPINTEROP_LLVM_VERSION_MAJOR}.x)")
+  message(STATUS "Found CppInterOp: config=${CPPINTEROP_CMAKE_DIR} dir=${CPPINTEROP_INSTALL_PREFIX} (found version=${CPPINTEROP_VERSION} compatible with Clang ${CPPINTEROP_LLVM_VERSION_MAJOR}.x)")
 endif()
 
 find_package(argparse REQUIRED)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Check https://github.com/compiler-research/CppInterOp/pull/336 and #166 

Variables coming out of cppinterop (`CPPINTEROP_CONFIG`, `CPPINTEROP_DIR` etc) were faulty leading to the following message
```
Found CppInterOp: config= dir= (found version= compatible with Clang 19.x)
```

Now that these have been fixed in 1.5.0, we have 
```
Found CppInterOp: config=/Users/anutosh491/micromamba/envs/xeus-cpp/lib/cmake/CppInterOp dir=/Users/anutosh491/micromamba/envs/xeus-cpp (found version=1.5.0 compatible with Clang 19.x)
```


## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
