### PR TITLE
Fix faulty CMAKE_FIND_ROOT_PATH_MODE_PACKAGE used for the wasm build

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -57,8 +57,6 @@ jobs:
 
           export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
           echo "PREFIX=$PREFIX" >> $GITHUB_ENV
-          export CMAKE_PREFIX_PATH=$PREFIX
-          export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
           export SYSROOT_PATH=$HOME/emsdk/upstream/emscripten/cache/sysroot
 
           emcmake cmake \

--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -63,10 +63,9 @@ jobs:
 
           emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
-            -DCMAKE_PREFIX_PATH=$PREFIX                       \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
             -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
-            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \
+            -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
             -DSYSROOT_PATH=$SYSROOT_PATH                      \
             ..
           emmake make -j  ${{ env.ncpus }} install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -261,10 +261,9 @@ jobs:
 
           emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
-            -DCMAKE_PREFIX_PATH=$PREFIX                       \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
             -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
-            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \
+            -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
             -DSYSROOT_PATH=$SYSROOT_PATH                      \
             ..
           emmake make -j  ${{ env.ncpus }} install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,8 +255,6 @@ jobs:
 
           export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
           echo "PREFIX=$PREFIX" >> $GITHUB_ENV
-          export CMAKE_PREFIX_PATH=$PREFIX
-          export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
           export SYSROOT_PATH=$HOME/emsdk/upstream/emscripten/cache/sysroot
 
           emcmake cmake \

--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ export SYSROOT_PATH=$HOME/emsdk/upstream/emscripten/cache/sysroot
 
 emcmake cmake \
         -DCMAKE_BUILD_TYPE=Release                        \
-        -DCMAKE_PREFIX_PATH=$PREFIX                       \
         -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
         -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
-        -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \
+        -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
         -DSYSROOT_PATH=$SYSROOT_PATH                      \
         ..
 emmake make install

--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
 mkdir build
 pushd build
 export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
-export CMAKE_PREFIX_PATH=$PREFIX
-export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
 export SYSROOT_PATH=$HOME/emsdk/upstream/emscripten/cache/sysroot
 
 emcmake cmake \

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -74,10 +74,9 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
     export SYSROOT_PATH=$HOME/emsdk/upstream/emscripten/cache/sysroot
     emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
-            -DCMAKE_PREFIX_PATH=$PREFIX                       \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
             -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
-            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \
+            -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
             -DSYSROOT_PATH=$SYSROOT_PATH                      \
             ..
     emmake make install

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -69,8 +69,6 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
     mkdir build
     pushd build
     export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
-    export CMAKE_PREFIX_PATH=$PREFIX
-    export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
     export SYSROOT_PATH=$HOME/emsdk/upstream/emscripten/cache/sysroot
     emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \


### PR DESCRIPTION
# Description

I'm not sure which PR introduced `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE` but it is being used wrongly.

[Cmake docs](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_ROOT_PATH_MODE_PACKAGE.html#variable:CMAKE_FIND_ROOT_PATH_MODE_PACKAGE) say that there are only 3 values this variables accepts 

1) ONLY
2) NEVER
3) BOTH

What we are using is something like `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON` which doesn't make sense (**its wrong but somehow the build just works**)

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [x] Required documentation updates
