### PR TITLE
Add example notebooks to deployment

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -76,13 +76,10 @@ jobs:
         run: |
           micromamba create -n xeus-lite-host jupyterlite-core
           micromamba activate xeus-lite-host
-          python -m pip install jupyterlite-xeus
-          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --output-dir dist
+          python -m pip install jupyterlite-xeus jupyter_server
+          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks --output-dir dist
           cp $PREFIX/bin/xcpp.data dist/extensions/@jupyterlite/xeus/static
           cp $PREFIX/lib/libclangCppInterOp.so dist/extensions/@jupyterlite/xeus/static
-          mkdir -p dist/files
-          mv notebooks dist/files
-          mv README.md dist/files
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

There is a known bug in Jupyter Lite where is jupyter_server is not installed then the contents flag doesn't work to upload files (see https://github.com/jupyterlite/jupyterlite/issues/1453). This PR adds this dependency to fix that so we can upload the example notebook (not everything in the notebook works).
Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
