### PR TITLE
Add jupyter notebook view as alternative to jupyter lab in deployment

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           micromamba create -n xeus-lite-host jupyterlite-core
           micromamba activate xeus-lite-host
-          python -m pip install jupyterlite-xeus jupyter_server
+          python -m pip install jupyterlite-xeus jupyter_server notebook
           jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks --output-dir dist
           cp $PREFIX/bin/xcpp.data dist/extensions/@jupyterlite/xeus/static
           cp $PREFIX/lib/libclangCppInterOp.so dist/extensions/@jupyterlite/xeus/static


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Please include a summary of changes, motivation and context for this PR.
This PR adds jupyter notebook view as alternative to jupyter lab view in the deployment, fixing some other warnings in the jupyter lite build too.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [x] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
