### PR TITLE
Add Windows 2025 server to ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,9 @@ jobs:
           - name: Windows22
             os: windows-2022
             micromamba_shell_init: cmd.exe
+          - name: Windows25
+            os: windows-2025
+            micromamba_shell_init: cmd.exe
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR adds a Windows sever 2025 build to the ci.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
