### PR TITLE
Change deploy runner to MacOS 15

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - name: Github-page
-            os: ubuntu-24.04
+            os: macos-15
             emsdk_ver: "3.1.45"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

The MacOS runners are faster. This will allow for faster deployment when new commits are made to the main branch.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
