### PR TITLE
Remove omp variable from non openmp kernels

### DIFF
--- a/share/jupyter/kernels/xcpp17/kernel.json.in
+++ b/share/jupyter/kernels/xcpp17/kernel.json.in
@@ -10,7 +10,7 @@
       "{connection_file}",
       "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
       "-I", "@XEUS_CPP_INCLUDE_DIR@",
-      "-std=c++17"@XEUS_CPP_OMP@
+      "-std=c++17"
   ],
   "language": "cpp",
   "metadata": {"debugger": false

--- a/share/jupyter/kernels/xcpp20/kernel.json.in
+++ b/share/jupyter/kernels/xcpp20/kernel.json.in
@@ -10,7 +10,7 @@
       "{connection_file}",
       "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
       "-I", "@XEUS_CPP_INCLUDE_DIR@",
-      "-std=c++20"@XEUS_CPP_OMP@
+      "-std=c++20"
   ],
   "language": "cpp",
   "metadata": {"debugger": false


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

These kernels do not support and openmp (and the plan is that the ones that do will be separate kernels). This PR removes references to openmp in the kernel configurations for the kernels currently being built.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
