### PR TITLE
Add jupyter lite contents flag instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ To build Jupyter Lite with this kernel without creating a website you can execut
 ```bash
 micromamba create -n xeus-lite-host jupyterlite-core
 micromamba activate xeus-lite-host
-python -m pip install jupyterlite-xeus
-jupyter lite build --XeusAddon.prefix=$PREFIX
+python -m pip install jupyterlite-xeus jupyter_server
+jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents ../notebooks/xeus-cpp-lite-demo.ipynb --output-dir dist
 ```
 
 We now need to shift necessary files like `xcpp.data` which contains the binary representation of the file(s)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To build Jupyter Lite with this kernel without creating a website you can execut
 micromamba create -n xeus-lite-host jupyterlite-core
 micromamba activate xeus-lite-host
 python -m pip install jupyterlite-xeus jupyter_server
-jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents ../notebooks/xeus-cpp-lite-demo.ipynb
+jupyter lite build --XeusAddon.prefix=$PREFIX --contents ../notebooks/xeus-cpp-lite-demo.ipynb
 ```
 
 We now need to shift necessary files like `xcpp.data` which contains the binary representation of the file(s)

--- a/README.md
+++ b/README.md
@@ -99,9 +99,8 @@ emmake make install
 
 To build Jupyter Lite with this kernel without creating a website you can execute the following
 ```bash
-micromamba create -n xeus-lite-host jupyterlite-core
+micromamba create -n xeus-lite-host jupyterlite-xeus jupyterlite-core jupyterlab notebook
 micromamba activate xeus-lite-host
-python -m pip install jupyterlite-xeus jupyter_server
 jupyter lite build --XeusAddon.prefix=$PREFIX --contents ../notebooks/xeus-cpp-lite-demo.ipynb
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To build Jupyter Lite with this kernel without creating a website you can execut
 micromamba create -n xeus-lite-host jupyterlite-core
 micromamba activate xeus-lite-host
 python -m pip install jupyterlite-xeus jupyter_server
-jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents ../notebooks/xeus-cpp-lite-demo.ipynb --output-dir dist
+jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents ../notebooks/xeus-cpp-lite-demo.ipynb
 ```
 
 We now need to shift necessary files like `xcpp.data` which contains the binary representation of the file(s)

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -86,7 +86,7 @@ To build Jupyter Lite with this kernel without creating a website you can execut
     micromamba create -n xeus-lite-host jupyterlite-core
     micromamba activate xeus-lite-host
     python -m pip install jupyterlite-xeus jupyter_server
-    jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents ../notebooks/xeus-cpp-lite-demo.ipynb --output-dir dist
+    jupyter lite build --XeusAddon.prefix=$PREFIX --contents ../notebooks/xeus-cpp-lite-demo.ipynb
 
 We now need to shift necessary files like `xcpp.data` which contains the binary representation of the file(s)
 we want to include in our application. As of now this would contain all important files like Standard Headers,

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -85,8 +85,8 @@ To build Jupyter Lite with this kernel without creating a website you can execut
 .. code-block:: bash
     micromamba create -n xeus-lite-host jupyterlite-core
     micromamba activate xeus-lite-host
-    python -m pip install jupyterlite-xeus
-    jupyter lite build --XeusAddon.prefix=$PREFIX
+    python -m pip install jupyterlite-xeus jupyter_server
+    jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents ../notebooks/xeus-cpp-lite-demo.ipynb --output-dir dist
 
 We now need to shift necessary files like `xcpp.data` which contains the binary representation of the file(s)
 we want to include in our application. As of now this would contain all important files like Standard Headers,


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR adds to the documentation the instructions the installing of jupyter_server so that users can add contents to their own deployments. I add an example to add the Jupyter Lite xeus-cpp demo notebook currently deployed for xeus-cpp.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [x] Required documentation updates
