### PR TITLE
Install libarchive c to remove jupyter lite build warning ci

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           micromamba create -n xeus-lite-host jupyterlite-core
           micromamba activate xeus-lite-host
-          python -m pip install jupyterlite-xeus jupyter_server notebook
+          python -m pip install jupyterlite-xeus jupyter_server notebook libarchive-c
           jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks/xeus-cpp-lite-demo.ipynb --output-dir dist
           cp $PREFIX/bin/xcpp.data dist/extensions/@jupyterlite/xeus/static
           cp $PREFIX/lib/libclangCppInterOp.so dist/extensions/@jupyterlite/xeus/static

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,7 +271,7 @@ jobs:
         run: |
           micromamba create -n xeus-lite-host jupyterlite-core
           micromamba activate xeus-lite-host
-          python -m pip install jupyterlite-xeus
+          python -m pip install jupyterlite-xeus libarchive-c
           jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }}
           cp $PREFIX/bin/xcpp.data _output/extensions/@jupyterlite/xeus/static
           cp $PREFIX/lib/libclangCppInterOp.so _output/extensions/@jupyterlite/xeus/static


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR installs libarchive-c to hopefully silence this warnining https://github.com/compiler-research/xeus-cpp/actions/runs/12721180808/job/35463797647#step:7:441 when building a jupyter lite site in the ci.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
