### PR TITLE
Remove conda forge channel from xeus-cpp wasm host environment

### DIFF
--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -1,7 +1,6 @@
 name: xeus-cpp-wasm-host
 channels:
   - https://repo.mamba.pm/emscripten-forge
-  - https://repo.mamba.pm/conda-forge
 dependencies:
   - nlohmann_json
   - xeus-lite


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

When we call the wasm environment we call it under the emscripten-wasm32 platform which doesn't exist for the conda forge channel. As  a result we get the following error in the build
https://github.com/compiler-research/xeus-cpp/actions/runs/12723529061/job/35468733198?pr=213#step:7:51 . Removing the reference to the conda-forge channel fixes this.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
