### PR TITLE
Upgrade jupyter kernel test to <0.8

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,7 +16,7 @@ dependencies:
   - zlib
   # Test dependencies
   - pytest
-  - jupyter_kernel_test>=0.5,<0.6
+  - jupyter_kernel_test>=0.5
   - papermill
   - nbformat
   - nbval

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,7 +16,7 @@ dependencies:
   - zlib
   # Test dependencies
   - pytest
-  - jupyter_kernel_test>=0.5
+  - jupyter_kernel_test<0.8
   - papermill
   - nbformat
   - nbval


### PR DESCRIPTION
# Description

Maybe I'm wrong but I don't feel like we need this restriction on the upper limit for jupyter kernel test.

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
