### PR TITLE
Add Ubuntu 22.04 and Ubuntu 24.04 arm runners to the ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,7 @@ jobs:
           - name: ubu22
             os: ubuntu-22.04
             emsdk_ver: "3.1.45"
+            micromamba_shell_init: bash
           - name: osx13-x86
             os: macos-13
             emsdk_ver: "3.1.45"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,9 @@ jobs:
           - name: ubu24
             os: ubuntu-24.04
             micromamba_shell_init: bash
+          - name: ubu24-arm
+            os: ubuntu-24.04-arm
+            micromamba_shell_init: bash
           - name: ubu24-analyzers
             os: ubuntu-24.04
             coverage: true
@@ -32,6 +35,9 @@ jobs:
             micromamba_shell_init: bash
           - name: ubu22
             os: ubuntu-22.04
+            micromamba_shell_init: bash
+          - name: ubu22-arm
+            os: ubuntu-22.04-arm
             micromamba_shell_init: bash
           - name: osx13-x86
             os: macos-13
@@ -194,8 +200,15 @@ jobs:
             os: ubuntu-24.04
             emsdk_ver: "3.1.45"
             micromamba_shell_init: bash
+          - name: ubu24-arm
+            os: ubuntu-24.04-arm
+            emsdk_ver: "3.1.45"
+            micromamba_shell_init: bash
           - name: ubu22
             os: ubuntu-22.04
+            emsdk_ver: "3.1.45"
+          - name: ubu22-arm
+            os: ubuntu-22.04-arm
             emsdk_ver: "3.1.45"
             micromamba_shell_init: bash
           - name: osx13-x86

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,17 +200,9 @@ jobs:
             os: ubuntu-24.04
             emsdk_ver: "3.1.45"
             micromamba_shell_init: bash
-          - name: ubu24-arm
-            os: ubuntu-24.04-arm
-            emsdk_ver: "3.1.45"
-            micromamba_shell_init: bash
           - name: ubu22
             os: ubuntu-22.04
             emsdk_ver: "3.1.45"
-          - name: ubu22-arm
-            os: ubuntu-22.04-arm
-            emsdk_ver: "3.1.45"
-            micromamba_shell_init: bash
           - name: osx13-x86
             os: macos-13
             emsdk_ver: "3.1.45"


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR adds support for Ubuntu 22.04 and Ubuntu 24.04 arm runners to the ci.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
