### PR TITLE
Fix online wasm build instructions

### DIFF
--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -46,7 +46,9 @@ Installation within a mamba environment (wasm build instructions)
 ========================
 
 These instructions will assume you have cmake installed on your system. First clone the repository, and move into that directory
+
 .. code-block:: bash
+
     git clone --depth=1 https://github.com/compiler-research/xeus-cpp.git
     cd ./xeus-cpp
 
@@ -54,6 +56,7 @@ These instructions will assume you have cmake installed on your system. First cl
 You'll now want to make sure you're using emsdk version "3.1.45" and activate it. You can get this by executing the following
 
 .. code-block:: bash
+
     cd $HOME
     git clone https://github.com/emscripten-core/emsdk.git
     cd emsdk
@@ -65,6 +68,7 @@ You'll now want to make sure you're using emsdk version "3.1.45" and activate it
 You are now in a position to build the xeus-cpp kernel. You build it by executing the following
 
 .. code-block:: bash
+
     micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
     mkdir build
     pushd build
@@ -83,22 +87,16 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
 To build Jupyter Lite with this kernel without creating a website you can execute the following
 
 .. code-block:: bash
+
     micromamba create -n xeus-lite-host jupyterlite-core
     micromamba activate xeus-lite-host
     python -m pip install jupyterlite-xeus
     jupyter lite build --XeusAddon.prefix=$PREFIX
 
-We now need to shift necessary files like `xcpp.data` which contains the binary representation of the file(s)
-we want to include in our application. As of now this would contain all important files like Standard Headers,
-Libraries etc coming out of emscripten's sysroot. Assuming we are still inside build we should do the following
-
-.. code-block:: bash
-    cp $PREFIX/bin/xcpp.data _output/extensions/@jupyterlite/xeus/static
-    cp $PREFIX/lib/libclangCppInterOp.so _output/extensions/@jupyterlite/xeus/static
-
 Once the Jupyter Lite site has built you can test the website locally by executing
 
 .. code-block:: bash
+
     jupyter lite serve --XeusAddon.prefix=$PREFIX
 
 Installing from conda-forge


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

The online documentation for xeus-cpp wasm builds was both not rendering correctly due to formatting issues, and was incorrect since it still had the instructions to copy file during the installation. This PR fixes this.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [x] Required documentation updates
