### PR TITLE
Fix wasm build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,9 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
 micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
 mkdir build
 cd build
-export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
-export SYSROOT_PATH=$PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
+export BUILD_TOOLS_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
+export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host
+export SYSROOT_PATH=$BUILD_TOOLS_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 
 emcmake cmake \
         -DCMAKE_BUILD_TYPE=Release                        \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,8 @@ cd ./xeus-cpp
 You'll now want to make sure you're using emsdk version "3.1.45" and activate it. You can get this by executing the following
 ```bash
 git clone https://github.com/emscripten-core/emsdk.git $HOME/emsdk
-$HOME/emsdk install 3.1.45
-$HOME/emsdk activate 3.1.45
+$HOME/emsdk/emsdk install 3.1.45
+$HOME/emsdk/emsdk activate 3.1.45
 source $HOME/emsdk/emsdk_env.sh
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,8 @@ emmake make install
 
 To build Jupyter Lite with this kernel without creating a website you can execute the following
 ```bash
-micromamba create -n xeus-lite-host jupyterlite-core
-micromamba activate xeus-lite-host -c conda-forge
+micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
+micromamba activate xeus-lite-host
 python -m pip install jupyterlite-xeus
 jupyter lite build --XeusAddon.prefix=$PREFIX
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,11 +70,9 @@ cd ./xeus-cpp
 
 You'll now want to make sure you're using emsdk version "3.1.45" and activate it. You can get this by executing the following
 ```bash
-cd $HOME
-git clone https://github.com/emscripten-core/emsdk.git
-cd emsdk
-./emsdk install 3.1.45
-./emsdk activate 3.1.45
+git clone https://github.com/emscripten-core/emsdk.git $HOME/emsdk
+$HOME/emsdk install 3.1.45
+$HOME/emsdk activate 3.1.45
 source $HOME/emsdk/emsdk_env.sh
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,9 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
 ```bash
 micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
 mkdir build
-pushd build
-export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
-export SYSROOT_PATH=$HOME/emsdk/upstream/emscripten/cache/sysroot
+cd build
+export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
+export SYSROOT_PATH=$PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 
 emcmake cmake \
         -DCMAKE_BUILD_TYPE=Release                        \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,12 +68,11 @@ git clone https://github.com/<your-github-username>/xeus-cpp.git
 cd ./xeus-cpp
 ```
 
-You'll now want to make sure you're using emsdk version "3.1.45" and activate it. You can get this by executing the following
+You'll now want to make sure you are using the same emsdk as the rest of our dependencies. This can be achieved by executing 
+the following
 ```bash
-git clone https://github.com/emscripten-core/emsdk.git $HOME/emsdk
-$HOME/emsdk/emsdk install 3.1.45
-$HOME/emsdk/emsdk activate 3.1.45
-source $HOME/emsdk/emsdk_env.sh
+micromamba create -f environment-wasm-build.yml -y
+micromamba activate xeus-cpp-wasm-build
 ```
 
 You are now in a position to build the xeus-cpp kernel. You build it by executing the following

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ emmake make install
 To build Jupyter Lite with this kernel without creating a website you can execute the following
 ```bash
 micromamba create -n xeus-lite-host jupyterlite-core
-micromamba activate xeus-lite-host
+micromamba activate xeus-lite-host -c conda-forge
 python -m pip install jupyterlite-xeus
 jupyter lite build --XeusAddon.prefix=$PREFIX
 ```

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ emmake make install
 
 To build Jupyter Lite with this kernel without creating a website you can execute the following
 ```bash
-micromamba create -n xeus-lite-host jupyterlite-core
-micromamba activate xeus-lite-host -c conda-forge
+micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
+micromamba activate xeus-lite-host
 python -m pip install jupyterlite-xeus
 jupyter lite build --XeusAddon.prefix=$PREFIX
 ```

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
 micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
 mkdir build
 cd build
-export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
-export SYSROOT_PATH=$PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
+export BUILD_TOOLS_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
+export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host
+export SYSROOT_PATH=$BUILD_TOOLS_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 
 emcmake cmake \
         -DCMAKE_BUILD_TYPE=Release                        \

--- a/README.md
+++ b/README.md
@@ -71,11 +71,9 @@ cd ./xeus-cpp
 
 You'll now want to make sure you're using emsdk version "3.1.45" and activate it. You can get this by executing the following
 ```bash
-cd $HOME
-git clone https://github.com/emscripten-core/emsdk.git
-cd emsdk
-./emsdk install 3.1.45
-./emsdk activate 3.1.45
+git clone https://github.com/emscripten-core/emsdk.git $HOME/emsdk
+$HOME/emsdk install 3.1.45
+$HOME/emsdk activate 3.1.45
 source $HOME/emsdk/emsdk_env.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ cd ./xeus-cpp
 You'll now want to make sure you're using emsdk version "3.1.45" and activate it. You can get this by executing the following
 ```bash
 git clone https://github.com/emscripten-core/emsdk.git $HOME/emsdk
-$HOME/emsdk install 3.1.45
-$HOME/emsdk activate 3.1.45
+$HOME/emsdk/emsdk install 3.1.45
+$HOME/emsdk/emsdk activate 3.1.45
 source $HOME/emsdk/emsdk_env.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ emmake make install
 To build Jupyter Lite with this kernel without creating a website you can execute the following
 ```bash
 micromamba create -n xeus-lite-host jupyterlite-core
-micromamba activate xeus-lite-host
+micromamba activate xeus-lite-host -c conda-forge
 python -m pip install jupyterlite-xeus
 jupyter lite build --XeusAddon.prefix=$PREFIX
 ```

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
 ```bash
 micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
 mkdir build
-pushd build
-export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
-export SYSROOT_PATH=$HOME/emsdk/upstream/emscripten/cache/sysroot
+cd build
+export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
+export SYSROOT_PATH=$PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 
 emcmake cmake \
         -DCMAKE_BUILD_TYPE=Release                        \

--- a/README.md
+++ b/README.md
@@ -69,12 +69,11 @@ git clone --depth=1 https://github.com/compiler-research/xeus-cpp.git
 cd ./xeus-cpp
 ```
 
-You'll now want to make sure you're using emsdk version "3.1.45" and activate it. You can get this by executing the following
+You'll now want to make sure you are using the same emsdk as the rest of our dependencies. This can be achieved by executing 
+the following
 ```bash
-git clone https://github.com/emscripten-core/emsdk.git $HOME/emsdk
-$HOME/emsdk/emsdk install 3.1.45
-$HOME/emsdk/emsdk activate 3.1.45
-source $HOME/emsdk/emsdk_env.sh
+micromamba create -f environment-wasm-build.yml -y
+micromamba activate xeus-cpp-wasm-build
 ```
 
 You are now in a position to build the xeus-cpp kernel. You build it by executing the following

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -86,8 +86,8 @@ To build Jupyter Lite with this kernel without creating a website you can execut
 
 .. code-block:: bash
 
-    micromamba create -n xeus-lite-host jupyterlite-core
-    micromamba activate xeus-lite-host -c conda-forge
+    micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
+    micromamba activate xeus-lite-host
     python -m pip install jupyterlite-xeus
     jupyter lite build --XeusAddon.prefix=$PREFIX
 

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -53,15 +53,14 @@ These instructions will assume you have cmake installed on your system. First cl
     cd ./xeus-cpp
 
 
-You'll now want to make sure you're using emsdk version "3.1.45" and activate it. You can get this by executing the following
+You'll now want to make sure you are using the same emsdk as the rest of our dependencies. This can be achieved by executing 
+the following
 
 .. code-block:: bash
 
-    git clone https://github.com/emscripten-core/emsdk.git $HOME/emsdk
-    $HOME/emsdk/emsdk install 3.1.45
-    $HOME/emsdk/emsdk activate 3.1.45
-    source $HOME/emsdk/emsdk_env.sh
 
+    micromamba create -f environment-wasm-build.yml -y
+    micromamba activate xeus-cpp-wasm-build
 
 You are now in a position to build the xeus-cpp kernel. You build it by executing the following
 

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -58,8 +58,8 @@ You'll now want to make sure you're using emsdk version "3.1.45" and activate it
 .. code-block:: bash
 
     git clone https://github.com/emscripten-core/emsdk.git $HOME/emsdk
-    $HOME/emsdk install 3.1.45
-    $HOME/emsdk activate 3.1.45
+    $HOME/emsdk/emsdk install 3.1.45
+    $HOME/emsdk/emsdk activate 3.1.45
     source $HOME/emsdk/emsdk_env.sh
 
 

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -57,11 +57,9 @@ You'll now want to make sure you're using emsdk version "3.1.45" and activate it
 
 .. code-block:: bash
 
-    cd $HOME
-    git clone https://github.com/emscripten-core/emsdk.git
-    cd emsdk
-    ./emsdk install 3.1.45
-    ./emsdk activate 3.1.45
+    git clone https://github.com/emscripten-core/emsdk.git $HOME/emsdk
+    $HOME/emsdk install 3.1.45
+    $HOME/emsdk activate 3.1.45
     source $HOME/emsdk/emsdk_env.sh
 
 

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -68,9 +68,9 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
 
     micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
     mkdir build
-    pushd build
-    export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
-    export SYSROOT_PATH=$HOME/emsdk/upstream/emscripten/cache/sysroot
+    cd build
+    export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
+    export SYSROOT_PATH=$PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
     emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -69,8 +69,9 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
     micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
     mkdir build
     cd build
-    export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
-    export SYSROOT_PATH=$PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
+    export BUILD_TOOLS_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
+    export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host
+    export SYSROOT_PATH=$BUILD_TOOLS_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
     emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -87,7 +87,7 @@ To build Jupyter Lite with this kernel without creating a website you can execut
 .. code-block:: bash
 
     micromamba create -n xeus-lite-host jupyterlite-core
-    micromamba activate xeus-lite-host
+    micromamba activate xeus-lite-host -c conda-forge
     python -m pip install jupyterlite-xeus
     jupyter lite build --XeusAddon.prefix=$PREFIX
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR fixes issues in the wasm build instructions. The first is that we cd into home to install and activate emsk, then try and activate yml file in xeus-cpp repo, but we are no longer in it. The second is that the micromamba create command doesn't work unless you point it towards the channel needed.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [x] Required documentation updates
