### PR TITLE
Update argparse dependency

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
   - nlohmann_json=3.11.3
   - CppInterOp>=1.5.0
   - pugixml
-  - cpp-argparse <3.1
+  - cpp-argparse>=3.0,<4.0
   - zlib
   # Test dependencies
   - pytest


### PR DESCRIPTION
# Description

Not sure why we have argparse pinned to less than 3.1 
Does anyone know why this was done ?

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Added/removed dependencies
- [ ] Required documentation updates
