### PR TITLE
Drop dependency on zlib

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,6 @@ dependencies:
   - CppInterOp>=1.5.0
   - pugixml
   - cpp-argparse <3.1
-  - zlib
   # Test dependencies
   - pytest
   - jupyter_kernel_test<0.8


### PR DESCRIPTION
# Description

Having zlib in the environment file looks unneccessary. Hence getting rid of it

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Added/removed dependencies
- [ ] Required documentation updates
