### PR TITLE
Update documentation about argparse no longer being <3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ source activate  "xeus-cpp"
 ```
 We will now install the dependencies needed to compile xeux-cpp from source within this environment by executing the following
 ```bash
-mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.3 jupyterlab CppInterOp cpp-argparse"<3.1" pugixml doctest -c conda-forge
+mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.3 jupyterlab CppInterOp cpp-argparse">=3.0,<4.0" pugixml doctest -c conda-forge
 ```
 Now you can compile the kernel from the source by executing (replace `$CONDA_PREFIX` with a custom installation prefix if need be)
 ```bash
@@ -132,7 +132,7 @@ http://xeus-cpp.readthedocs.io
 
 | `xeus-cpp` | `xeus-zmq`      | `CppInterOp` | `pugixml` | `cpp-argparse`| `nlohmann_json` |
 |------------|-----------------|--------------|-----------|---------------|-----------------|
-|  main      |  >=3.0.0,<4.0.0 | >=1.5.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
+|  main      |  >=3.0.0,<4.0.0 | >=1.5.0      | ~1.8.1    | >=3.0,<4.0    | >=3.11.3,<4.0   |
 |  0.6.0     |  >=3.0.0,<4.0.0 | >=1.5.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
 |  0.5.0     |  >=3.0.0,<4.0.0 | >=1.3.0      | ~1.8.1    | <3.1          | >=3.11.3,<4.0   |
 

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -30,7 +30,7 @@ this environment by executing the following
 .. code-block:: bash
 
     mamba install notebook cmake cxx-compiler xeus-zmq nlohmann_json=3.11.3
-    jupyterlab CppInterOp cpp-argparse<3.1 pugixml doctest -c conda-forge
+    jupyterlab CppInterOp cpp-argparse">=3.0,<4.0" pugixml doctest -c conda-forge
 
 Now you can compile the kernel from the source by executing (replace `$CONDA_PREFIX` 
 with a custom installation prefix if need be)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR https://github.com/compiler-research/xeus-cpp/pull/237 should have had documentation changes. This PR makes those changes.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [x] Required documentation updates
