### PR TITLE
Remove emsdk_ver matrix option from deploy workflow

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - name: Github-page
             os: ubuntu-24.04
-            emsdk_ver: "3.1.45"
+
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This option is no longer used in the deploy workflow, since it uses the emsdk from emscripten-forge. This PR just simply removes the option.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
