### PR TITLE
Avoid Untitled*.ipynb notebooks when add files to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@
 # Jupyter
 .ipynb_checkpoints/
 
+# Default names for Jupyter notebooks
+Untitled*.ipynb
+
 # Python
 __pycache__/
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR adds Untitled*.ipynb to the .gitignore so that none of the default named notebooks are added to the repo by accident.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
