### PR TITLE
Added target_compile_definitions for XEUS_SEARCH_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,8 @@ macro(xeus_cpp_create_target target_name linkage output_name)
         target_link_libraries(${target_name} PRIVATE ${CMAKE_THREAD_LIBS_INIT})
     endif()
 
+    target_compile_definitions(${target_name} PRIVATE "XEUS_SEARCH_PATH=\"$<JOIN:$<TARGET_PROPERTY:${target_name},INCLUDE_DIRECTORIES>,:>\"")
+
 endmacro()
 
 # xeus-cpp-headers

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -46,6 +46,19 @@ void* createInterpreter(const Args &ExtraArgs = {}) {
     ClangArgs.push_back(CxxInclude.c_str());
   }
 #endif
+
+#ifdef XEUS_SEARCH_PATH
+  std::string search_path = XEUS_SEARCH_PATH;
+  std::istringstream iss(search_path);
+  std::string path;
+  while (std::getline(iss, path, ':')) {
+      if (!path.empty()) {
+          ClangArgs.push_back("-I");
+          ClangArgs.push_back(path.c_str());
+      }
+  }
+#endif
+
   ClangArgs.insert(ClangArgs.end(), ExtraArgs.begin(), ExtraArgs.end());
   // FIXME: We should process the kernel input options and conditionally pass
   // the gpu args here.


### PR DESCRIPTION
# Description

This PR introduces a change to the build system by adding a `target_compile_definitions` directive for `XEUS_SEARCH_PATH`. The added definition dynamically sets the include directories for the `xeus-cpp` project by joining the values of the `INCLUDE_DIRECTORIES` property.

I have tried to take a similar approach as was taken for xeus-cling.

Fixes #175

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
