### PR TITLE
Added XEUS_SEARCH_PATH support in xeus-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,12 +460,21 @@ if(EMSCRIPTEN)
     # 3) Shift the resource dir and the sysroot to a common location.
     # 4) Preload everything required together.
 endif()
+
 # Tests
 # =====
 
 if(XEUS_CPP_BUILD_TESTS)
     add_subdirectory(test)
 endif()
+
+set(XEUS_SEARCH_PATH $<JOIN:$<TARGET_PROPERTY:xeus-cpp,INCLUDE_DIRECTORIES>,:>)
+
+if (NOT EMSCRIPTEN)
+    set(XEUS_SEARCH_PATH "${XEUS_SEARCH_PATH}:${CMAKE_CURRENT_SOURCE_DIR}/src")
+endif()
+
+target_compile_definitions(xeus-cpp PRIVATE "XEUS_SEARCH_PATH=\"${XEUS_SEARCH_PATH}\"")
 
 # Installation
 # ============

--- a/include/xeus-cpp/xinterpreter.hpp
+++ b/include/xeus-cpp/xinterpreter.hpp
@@ -12,6 +12,7 @@
 #define XEUS_CPP_INTERPRETER_HPP
 
 #include <memory>
+#include <sstream>
 #include <streambuf>
 #include <string>
 #include <vector>

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -112,6 +112,7 @@ __get_cxx_version ()
         createInterpreter(Args(argv ? argv + 1 : argv, argv + argc));
         m_version = get_stdopt();
         redirect_output();
+        init_includes();
         init_preamble();
         init_magic();
     }
@@ -354,6 +355,20 @@ __get_cxx_version ()
     void interpreter::publish_stderr(const std::string& s)
     {
         publish_stream("stderr", s);
+    }
+
+    void interpreter::init_includes()
+    {
+        Cpp::AddIncludePath((xeus::prefix_path() + "/include/").c_str());
+        if (const char* paths = std::getenv("XEUS_SEARCH_PATH")) {
+            std::istringstream stream(paths);
+            std::string path;
+            char delimiter = (std::string(paths).find(';') != std::string::npos) ? ';' : ':';
+            
+            while (std::getline(stream, path, delimiter))
+                if (!path.empty()) 
+                    Cpp::AddIncludePath(path.c_str());
+        }
     }
 
     void interpreter::init_preamble()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,3 +67,14 @@ target_link_libraries(test_xeus_cpp xeus-cpp doctest::doctest ${CMAKE_THREAD_LIB
 target_include_directories(test_xeus_cpp PRIVATE ${XEUS_CPP_INCLUDE_DIR})
 
 add_custom_target(xtest COMMAND test_xeus_cpp DEPENDS test_xeus_cpp)
+
+# Test for non-standard include paths
+add_executable(test_include_paths test_include_paths.cpp)
+target_link_libraries(test_include_paths PRIVATE doctest::doctest)
+target_include_directories(test_include_paths PRIVATE 
+    ${CMAKE_SOURCE_DIR}/test/custom_includes
+    ${DOCTEST_INCLUDE_DIR}
+)
+target_compile_definitions(test_include_paths PRIVATE DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN)
+add_test(NAME test_include_paths COMMAND test_include_paths)
+

--- a/test/custom_includes/test_header.hpp
+++ b/test/custom_includes/test_header.hpp
@@ -1,0 +1,8 @@
+#ifndef TEST_HEADER_HPP
+#define TEST_HEADER_HPP
+
+namespace test_ns {
+    constexpr int test_value = 42;
+}
+
+#endif

--- a/test/test_include_paths.cpp
+++ b/test/test_include_paths.cpp
@@ -1,0 +1,8 @@
+#include <doctest/doctest.h>
+#include <string>
+#include "test_header.hpp"
+
+TEST_CASE("Test non-standard include paths")
+{
+    CHECK(test_ns::test_value == 42);
+}


### PR DESCRIPTION
# Description
Added ```interpreter::init_includes``` function and added ```XEUS_SEARCH_PATH``` in CMakeLists.txt. 

## Key Changes
1. Parsing the XEUS_SEARCH_PATH environment variable in ```interpreter::init_includes```.
2. Updates to ```CMakeLists.txt``` and ```/test/CMakeLists.txt``` for joining include directories and testing respectively.

Fixes #175 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
