### PR TITLE
Fix Inspect Request Failure in xeus-cpp-lite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,6 +447,8 @@ if(EMSCRIPTEN)
     target_link_options(xcpp
         PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS='[\"FS\",\"PATH\",\"LDSO\",\"loadDynamicLibrary\",\"ERRNO_CODES\"]'"
         PUBLIC "SHELL: --preload-file ${SYSROOT_PATH}/include@/include"
+        PUBLIC "SHELL: --preload-file ${XEUS_CPP_DATA_DIR}@/share/xeus-cpp"
+        PUBLIC "SHELL: --preload-file ${XEUS_CPP_CONF_DIR}@/etc/xeus-cpp"
         PUBLIC "SHELL: --post-js ${CMAKE_CURRENT_SOURCE_DIR}/wasm_patches/post.js"
     )
     # TODO: Emscripten supports preloading files just once before it generates

--- a/notebooks/xeus-cpp-lite-demo.ipynb
+++ b/notebooks/xeus-cpp-lite-demo.ipynb
@@ -233,7 +233,7 @@
       "execution_count": 10
     },
     {
-      "id": "3249788b-d4e0-4e9a-8e75-aebbc88d3439",
+      "id": "67181378-69d0-4adb-8a69-9abd20d3bc85",
       "cell_type": "code",
       "source": "FooT<double> foot(1.2);\nfoot.print();",
       "metadata": {
@@ -247,6 +247,31 @@
         }
       ],
       "execution_count": 11
+    },
+    {
+      "id": "6ce20171-18cb-4373-874b-89e6a2d2e425",
+      "cell_type": "markdown",
+      "source": "## Documentation\n\n - Documentation for types of the standard library is retrieved on cppreference.com.",
+      "metadata": {}
+    },
+    {
+      "id": "c723686c-a70b-4e68-a175-b2224f0616aa",
+      "cell_type": "code",
+      "source": "?std::vector",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/html": "<style>\n            #pager-container {\n                padding: 0;\n                margin: 0;\n                width: 100%;\n                height: 100%;\n            }\n            .xcpp-iframe-pager {\n                padding: 0;\n                margin: 0;\n                width: 100%;\n                height: 100%;\n                border: none;\n            }\n            </style>\n            <iframe class=\"xcpp-iframe-pager\" src=\"https://en.cppreference.com/w/cpp/container/vector?action=purge\"></iframe>",
+            "text/plain": "https://en.cppreference.com/w/cpp/container/vector"
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 12
     },
     {
       "id": "afee187b-2e6a-47db-acb1-8dab5a975565",
@@ -278,7 +303,7 @@
         "trusted": true
       },
       "outputs": [],
-      "execution_count": 12
+      "execution_count": 13
     },
     {
       "id": "b326166f-1652-4cd5-bc8e-e4fa93f848a6",
@@ -288,7 +313,7 @@
         "trusted": true
       },
       "outputs": [],
-      "execution_count": 13
+      "execution_count": 14
     },
     {
       "id": "c32f5494-00e8-4427-bf6a-ce20c31ab44e",
@@ -298,7 +323,7 @@
         "trusted": true
       },
       "outputs": [],
-      "execution_count": 14
+      "execution_count": 15
     },
     {
       "id": "fc494113-8283-4d27-93b1-055ce5ee8240",
@@ -316,7 +341,7 @@
           "metadata": {}
         }
       ],
-      "execution_count": 15
+      "execution_count": 16
     },
     {
       "id": "b1c0a821-e794-4f31-a791-85536d997069",
@@ -332,7 +357,7 @@
         "trusted": true
       },
       "outputs": [],
-      "execution_count": 16
+      "execution_count": 17
     },
     {
       "id": "0cc2ee8f-955e-459a-847f-1729ea961710",
@@ -342,7 +367,7 @@
         "trusted": true
       },
       "outputs": [],
-      "execution_count": 17
+      "execution_count": 18
     },
     {
       "id": "e4de8992-2ffa-4493-8d86-f3738b1f8e97",
@@ -360,7 +385,7 @@
           "metadata": {}
         }
       ],
-      "execution_count": 18
+      "execution_count": 19
     },
     {
       "id": "f287b246-e1e2-4e5c-9167-89cd2b6b0de0",
@@ -376,7 +401,7 @@
         "trusted": true
       },
       "outputs": [],
-      "execution_count": 19
+      "execution_count": 20
     },
     {
       "id": "104f5359-2518-4a4c-bb79-b5b52041d745",
@@ -394,7 +419,7 @@
           "metadata": {}
         }
       ],
-      "execution_count": 20
+      "execution_count": 21
     },
     {
       "id": "8f6ab60e-eabf-4ecc-b856-a3e7f6b165b9",
@@ -404,7 +429,7 @@
         "trusted": true
       },
       "outputs": [],
-      "execution_count": 21
+      "execution_count": 22
     },
     {
       "id": "aa21443e-f927-4af1-b2ba-46ddd76dee65",
@@ -420,7 +445,7 @@
         "trusted": true
       },
       "outputs": [],
-      "execution_count": 22
+      "execution_count": 23
     },
     {
       "id": "7e05d371-633d-4419-95d1-29f77985859b",
@@ -436,7 +461,7 @@
           "text": "goodbye\n"
         }
       ],
-      "execution_count": 23
+      "execution_count": 24
     },
     {
       "id": "101ce1e3-9875-49ab-bf9b-e4e69ad4bf68",
@@ -452,17 +477,7 @@
           "text": "goodbye\n"
         }
       ],
-      "execution_count": 24
-    },
-    {
-      "id": "2ef73723-91d4-4c62-9a46-d64a96ccb49e",
-      "cell_type": "code",
-      "source": "",
-      "metadata": {
-        "trusted": true
-      },
-      "outputs": [],
-      "execution_count": null
+      "execution_count": 25
     }
   ]
 }


### PR DESCRIPTION
# Description

This PR resolves the issue where ```?std::vector``` and similar inspect requests were failing in xeus-cpp-lite when built with WebAssembly (WASM) options. The inspect request was unable to locate the tag files correctly.

Fixes #229 

## Changes
1. Ensured that ```--preload-file``` correctly includes the required tag files by adding
```
PUBLIC "SHELL: --preload-file ${XEUS_CPP_DATA_DIR}@/share/xeus-cpp"
PUBLIC "SHELL: --preload-file ${XEUS_CPP_CONF_DIR}@/etc/xeus-cpp"
```
in ```target-link-options``` while building for ```EMSCRIPTEN```.

2. Added demo of inspect request for getting documentation in ```/notebooks/xeus-cpp-lite-demo.ipynb```.

## Screenshot
![inspect-working](https://github.com/user-attachments/assets/aa547c4a-7f1b-43bf-960b-deed5efba22b)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix

