### PR TITLE
Doc change

### DIFF
--- a/docs/source/dev-build-options.rst
+++ b/docs/source/dev-build-options.rst
@@ -34,5 +34,5 @@ If ``XEUS_CPP_USE_SHARED_XEUS_CPP`` is disabled, xcpp  will be linked statically
 Building the Tests
 ~~~~~~~~~~~~~~~~~~
 
-- ``XEUS_CPP_BUILD_TESTS``: enables the tests. **Disabled by default**.
+- ``XEUS_CPP_BUILD_TESTS``: enables the tests. **Enabled by default.**.
 

--- a/docs/source/dev-build-options.rst
+++ b/docs/source/dev-build-options.rst
@@ -34,5 +34,5 @@ If ``XEUS_CPP_USE_SHARED_XEUS_CPP`` is disabled, xcpp  will be linked statically
 Building the Tests
 ~~~~~~~~~~~~~~~~~~
 
-- ``XEUS_CPP_BUILD_TESTS``: enables the tests. **Enabled by default.**.
+- ``XEUS_CPP_BUILD_TESTS``: enables the tests. **Enabled by default**.
 


### PR DESCRIPTION
# Description
```XEUS_CPP_BUILD_TESTS``` are enabled by default.

Fixes #262

## Type of change
- [x] Required documentation updates
