### PR TITLE
Remove lower bound on xeus-zmq version environment-dev.yml

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,7 @@ dependencies:
   - cxx-compiler=1.7.0
   # Host dependencies
   - xeus>=5.0.0
-  - xeus-zmq>=3.0,<4.0
+  - xeus-zmq<4.0
   - nlohmann_json=3.11.3
   - CppInterOp
   - pugixml


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Conda will automatically pick the most recent release of xeus-zmq it can. Therefore the lower bound is not necessary in the yml file. We just need to make sure we don't pick a version 4 release when it happens in case we are not compatible with it.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
