### PR TITLE
Remove XEUS_CPP_INCLUDE_DOCS in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,7 +551,3 @@ if(EMSCRIPTEN)
             "$<TARGET_FILE_DIR:xcpp>/xcpp.data"
             DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif ()
-
-if(XEUS_CPP_INCLUDE_DOCS)
-    add_subdirectory(docs)
-endif()


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

As the cmake is not currently designed to build the docs despite having XEUS_CPP_INCLUDE_DOCS defined this PR removes the section which mentions this variable. The variable is assumed to be part of an old PR which never got spotted before merge.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
