### PR TITLE
Mention the Jupyter Lite deployment on the read the docs homepage

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,8 +12,11 @@ Introduction
 ------------
 
 ``xeus-cpp`` is a Jupyter kernel for cpp based on the native implementation of
-the Jupyter protocol xeus_. Try a Jupyter Lite demo of xeus-cpp by clicking 
-`here <https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://compiler-research.github.io/xeus-cpp/lab/index.html>`
+the Jupyter protocol xeus_. Try a Jupyter Lite demo of xeus-cpp by clicking
+
+.. image:: https://jupyterlite.rtfd.io/en/latest/_static/badge.svg
+   :target: https://compiler-research.github.io/xeus-cpp/lab/index.html
+   :alt: lite-badge
 
 Licensing
 ---------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,8 @@ Introduction
 ------------
 
 ``xeus-cpp`` is a Jupyter kernel for cpp based on the native implementation of
-the Jupyter protocol xeus_.
+the Jupyter protocol xeus_. Try a Jupyter Lite demo of xeus-cpp by clicking 
+`here <https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://compiler-research.github.io/xeus-cpp/lab/index.html>`
 
 Licensing
 ---------


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

We currently only talk about the Jupyter Lite deployment in the readme file. This makes the deployment more visible
by adding a link in the main page of xeus-cpp read the docs page. 

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [x] Required documentation updates
