### PR TITLE
Make use of EMSDK environment variable which comes from sourcing emsdk script

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -50,17 +50,15 @@ jobs:
           mkdir build
           pushd build
 
-          export BUILD_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
           export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host 
           echo "PREFIX=$PREFIX" >> $GITHUB_ENV
-          export SYSROOT_PATH=$BUILD_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 
           emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
             -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
             -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
-            -DSYSROOT_PATH=$SYSROOT_PATH                      \
+            -DSYSROOT_PATH=$EMSDK/upstream/emscripten/cache/sysroot  \
             ..
           emmake make -j ${{ env.ncpus }} install
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,17 +233,15 @@ jobs:
           mkdir build
           pushd build
 
-          export BUILD_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
           export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host
           echo "PREFIX=$PREFIX" >> $GITHUB_ENV
-          export SYSROOT_PATH=$BUILD_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 
           emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
             -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
             -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
-            -DSYSROOT_PATH=$SYSROOT_PATH                      \
+            -DSYSROOT_PATH=$EMSDK/upstream/emscripten/cache/sysroot  \
             ..
           emmake make -j ${{ env.ncpus }} install
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,16 +80,14 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
 micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
 mkdir build
 cd build
-export BUILD_TOOLS_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
 export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host
-export SYSROOT_PATH=$BUILD_TOOLS_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 
 emcmake cmake \
         -DCMAKE_BUILD_TYPE=Release                        \
         -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
         -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
         -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
-        -DSYSROOT_PATH=$SYSROOT_PATH                      \
+        -DSYSROOT_PATH=$EMSDK/upstream/emscripten/cache/sysroot  \
         ..
 emmake make install
 ```

--- a/README.md
+++ b/README.md
@@ -81,16 +81,14 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
 micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
 mkdir build
 cd build
-export BUILD_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
 export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host
-export SYSROOT_PATH=$BUILD_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 
 emcmake cmake \
         -DCMAKE_BUILD_TYPE=Release                        \
         -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
         -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
         -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
-        -DSYSROOT_PATH=$SYSROOT_PATH                      \
+        -DSYSROOT_PATH=$EMSDK/upstream/emscripten/cache/sysroot  \
         ..
 emmake make install
 ```

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -69,15 +69,13 @@ You are now in a position to build the xeus-cpp kernel. You build it by executin
     micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
     mkdir build
     cd build
-    export BUILD_TOOLS_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-build
     export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-cpp-wasm-host
-    export SYSROOT_PATH=$BUILD_TOOLS_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
     emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
             -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
             -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
-            -DSYSROOT_PATH=$SYSROOT_PATH                      \
+            -DSYSROOT_PATH=$EMSDK/upstream/emscripten/cache/sysroot  \
             ..
     emmake make install
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

xeus-cpp instructions create a BUILD_PREFIX and SYSROOT_PATH environment variable. It would be better to just utilise the EMSDK environment variable which comes from when you setup emsdk. Also since we only use SYSROOT_PATH once it makes no sense for it to be an environment variable. We can just put the path directly into the cmake configure stage. 

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [x] Required documentation updates
