### PR TITLE
Update ZedThree/clang-tidy-review to version 0.21.0

### DIFF
--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Post review comments
         id: post-review
-        uses: ZedThree/clang-tidy-review/post@v0.20.1
+        uses: ZedThree/clang-tidy-review/post@v0.21.0
         with:
           max_comments: 10
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -53,4 +53,4 @@ jobs:
             cmake . -B build -DCMAKE_C_COMPILER="$GITHUB_WORKSPACE/llvm/bin/clang" -DCMAKE_CXX_COMPILER="$GITHUB_WORKSPACE/llvm/bin/clang++" -DCMAKE_EXPORT_COMPILE_COMMANDS=On
             
       - name: Upload artifacts
-        uses: ZedThree/clang-tidy-review/upload@v0.20.1
+        uses: ZedThree/clang-tidy-review/upload@v0.21.0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -30,7 +30,7 @@ jobs:
           version: "17.0.6"
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.20.1
+        uses: ZedThree/clang-tidy-review@v0.21.0
         id: review
         with:
           build_dir: build


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR updates ZedThree/clang-tidy-review to version 0.21.0 due this issue in version 0.20.1 https://github.com/ZedThree/clang-tidy-review/issues/144

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
