### PR TITLE
Pinning nlohmann_json version for xeus-cpp-lite

### DIFF
--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -3,7 +3,7 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
   - https://repo.mamba.pm/conda-forge
 dependencies:
-  - nlohmann_json
+  - nlohmann_json=3.11.3
   - xeus-lite
   - xeus
   - CppInterOp


### PR DESCRIPTION
# Description

nlohmann_json `3.12.0` was out this week and the current xeus version is only compatible with `3.11.*` due to reasons mentioned here 

https://github.com/jupyter-xeus/xeus/blob/055829bb0cccd1c5afe904a222c33770d98ef860/CMakeLists.txt#L78-L83


So we have the dependency pinned for our native builds 

https://github.com/compiler-research/xeus-cpp/blob/d7699c00f462d9a6457eb07f328f2b2b91dd5201/environment-dev.yml#L12

But not for our lite build (**So possibly our nightly build should show the error by today/tomorrow when micromamba would pick up 3.12.0 instead of 3.11.3**) 

I tried the same on my local fork and we would see this error https://github.com/anutosh491/xeus-cpp/actions/runs/14429314765/job/40462192706?pr=8


So pinning it to avoid any errors in the future.



Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Added/removed dependencies
- [ ] Required documentation updates
