### PR TITLE
Add Windows arm Github runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,9 @@ jobs:
           - name: Windows25
             os: windows-2025
             micromamba_shell_init: cmd.exe
+          - name: Windows11-arm
+            os: windows-11-arm
+            micromamba_shell_init: cmd.exe
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

According to https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/ Windows arm Github runners are now available for free for public repositories. Therefore I have added them to our ci. Hopefully they pass the same tests as Windows x86, but won't know until the workflow runs.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
