### PR TITLE
Disable xsystem for WASM

### DIFF
--- a/src/xsystem.hpp
+++ b/src/xsystem.hpp
@@ -28,6 +28,14 @@ namespace xcpp
 
         void apply(const std::string& code, nl::json& kernel_res) override
         {
+#if defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+            // WASM environment: Disable shell commands
+            kernel_res["status"] = "error";
+            kernel_res["ename"] = "UnsupportedEnvironment";
+            kernel_res["evalue"] = "Shell commands are not supported in the WASM environment.";
+            kernel_res["traceback"] = nl::json::array();
+#else
+            // Native environment: Execute shell commands
             std::regex re(spattern + R"((.*))");
             std::smatch to_execute;
             std::regex_search(code, to_execute, re);
@@ -65,6 +73,7 @@ namespace xcpp
                 kernel_res["evalue"] = "evalue";
                 kernel_res["traceback"] = nl::json::array();
             }
+#endif
         }
 
         [[nodiscard]] std::unique_ptr<xpreamble> clone() const override

--- a/src/xsystem.hpp
+++ b/src/xsystem.hpp
@@ -28,14 +28,6 @@ namespace xcpp
 
         void apply(const std::string& code, nl::json& kernel_res) override
         {
-#if defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
-            // WASM environment: Disable shell commands
-            kernel_res["status"] = "error";
-            kernel_res["ename"] = "UnsupportedEnvironment";
-            kernel_res["evalue"] = "Shell commands are not supported in the WASM environment.";
-            kernel_res["traceback"] = nl::json::array();
-#else
-            // Native environment: Execute shell commands
             std::regex re(spattern + R"((.*))");
             std::smatch to_execute;
             std::regex_search(code, to_execute, re);
@@ -73,7 +65,6 @@ namespace xcpp
                 kernel_res["evalue"] = "evalue";
                 kernel_res["traceback"] = nl::json::array();
             }
-#endif
         }
 
         [[nodiscard]] std::unique_ptr<xpreamble> clone() const override

--- a/test/test_interpreter.cpp
+++ b/test/test_interpreter.cpp
@@ -654,15 +654,10 @@ TEST_SUITE("xsystem_clone")
     }
 }
 
+#if !defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
 TEST_SUITE("xsystem_apply")
 {
-#if defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
-    TEST_CASE("apply_xsystem"
-            * doctest::should_fail(true)
-            * doctest::description("TODO: Currently fails for the Emscripten build"))
-#else
     TEST_CASE("apply_xsystem")
-#endif
     {
         xcpp::xsystem system;
         std::string code = "!echo Hello, World!";
@@ -673,6 +668,7 @@ TEST_SUITE("xsystem_apply")
         REQUIRE(kernel_res["status"] == "ok");
     }
 }
+#endif
 
 TEST_SUITE("xmagics_contains"){
     TEST_CASE("bad_status_cell") {


### PR DESCRIPTION
# Description

Shell commands do not work in WASM environment. This PR disables it.

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
