### PR TITLE
Pin nlohmann_json to 3.12.0

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,7 +9,7 @@ dependencies:
   # Host dependencies
   - xeus>=5.0.0
   - xeus-zmq<4.0
-  - nlohmann_json=3.11.3
+  - nlohmann_json
   - CppInterOp
   - pugixml
   - cpp-argparse>=3.0,<4.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,7 +9,7 @@ dependencies:
   # Host dependencies
   - xeus>=5.0.0
   - xeus-zmq<4.0
-  - nlohmann_json
+  - nlohmann_json=3.12.0
   - CppInterOp
   - pugixml
   - cpp-argparse>=3.0,<4.0

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -3,9 +3,9 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
   - https://repo.mamba.pm/conda-forge
 dependencies:
-  - nlohmann_json=3.11.3
+  - nlohmann_json
   - xeus-lite
-  - xeus=5.2.0
+  - xeus
   - CppInterOp
   - cpp-argparse
   - pugixml

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -3,7 +3,7 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
   - https://repo.mamba.pm/conda-forge
 dependencies:
-  - nlohmann_json
+  - nlohmann_json=3.12.0
   - xeus-lite
   - xeus
   - CppInterOp

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -3,9 +3,9 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
   - https://repo.mamba.pm/conda-forge
 dependencies:
-  - nlohmann_json
+  - nlohmann_json=3.11.3
   - xeus-lite
-  - xeus
+  - xeus=5.2.0
   - CppInterOp
   - cpp-argparse
   - pugixml

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -3,7 +3,7 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
   - https://repo.mamba.pm/conda-forge
 dependencies:
-  - nlohmann_json=3.11.3
+  - nlohmann_json
   - xeus-lite
   - xeus
   - CppInterOp


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

The latest release of xeus got released, and requires nlohmann_json to be 3.12.0 . Until this PR is in the ci will fail
(see https://github.com/compiler-research/xeus-cpp/actions/runs/14604191183/job/40969335106#step:5:97).

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
