### PR TITLE
Removed build_interpreter from main()

### DIFF
--- a/include/xeus-cpp/xutils.hpp
+++ b/include/xeus-cpp/xutils.hpp
@@ -25,9 +25,6 @@ namespace xcpp
     void stop_handler(int sig);
 
     XEUS_CPP_API
-    interpreter_ptr build_interpreter(int argc, char** argv);
-
-    XEUS_CPP_API
     std::string retrieve_tagconf_dir();
 
     XEUS_CPP_API

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
     signal(SIGINT, xcpp::stop_handler);
 
     std::string file_name = xeus::extract_filename(argc, argv);
-    interpreter_ptr interpreter = xcpp::build_interpreter(argc, argv);
+    auto interpreter = std::unique_ptr<xcpp::interpreter>(new xcpp::interpreter(argc, argv));
     std::unique_ptr<xeus::xcontext> context = xeus::make_zmq_context();
 
     if (!file_name.empty())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
     signal(SIGINT, xcpp::stop_handler);
 
     std::string file_name = xeus::extract_filename(argc, argv);
-    auto interpreter = std::unique_ptr<xcpp::interpreter>(new xcpp::interpreter(argc, argv));
+    auto interpreter = std::make_unique<xcpp::interpreter>(argc, argv);
     std::unique_ptr<xeus::xcontext> context = xeus::make_zmq_context();
 
     if (!file_name.empty())

--- a/src/xutils.cpp
+++ b/src/xutils.cpp
@@ -50,21 +50,6 @@ namespace xcpp
         exit(0);
     }
 
-    interpreter_ptr build_interpreter(int argc, char** argv)
-    {
-        std::vector<const char*> interpreter_argv(argc);
-        interpreter_argv[0] = "xeus-cpp";
-
-        // Copy all arguments in the new vector excepting the process name.
-        for (int i = 1; i < argc; i++)
-        {
-            interpreter_argv[i] = argv[i];
-        }
-
-        interpreter_ptr interp_ptr = std::make_unique<interpreter>(argc, interpreter_argv.data());
-        return interp_ptr;
-    }
-
     std::string retrieve_tagconf_dir()
     {
         const char* tagconf_dir_env = std::getenv("XCPP_TAGCONFS_DIR");

--- a/test/test_interpreter.cpp
+++ b/test/test_interpreter.cpp
@@ -344,24 +344,6 @@ TEST_SUITE("trim"){
 
 }
 
-TEST_SUITE("build_interpreter")
-{
-    // This test case checks if the function `build_interpreter` returns a non-null pointer
-    // when valid arguments are passed. It sets up a scenario with valid command line arguments
-    // and checks if the function returns a non-null pointer.
-    TEST_CASE("build_interpreter_pointer_not_null")
-    {
-        char arg1[] = "program_name";
-        char arg2[] = "-option1";
-        char* argv[] = {arg1, arg2};
-        int argc = 2;
-
-        interpreter_ptr interp_ptr = xcpp::build_interpreter(argc, argv);
-
-        REQUIRE(interp_ptr != nullptr);
-    }
-}
-
 TEST_SUITE("is_match_magics_manager")
 {
     // This test case checks if the function `is_match` correctly identifies strings that match


### PR DESCRIPTION
# Description

In the main function, call to ```build_interpreter``` is redundant. Instead calling directly to ```xcpp::interpreter::interpreter``` will work fine. 

### Reasoning

```cpp
interpreter_ptr build_interpreter(int argc, char** argv)
{
    std::vector<const char*> interpreter_argv(argc);
    interpreter_argv[0] = "xeus-cpp";

    // Copy all arguments in the new vector excepting the process name.
    for (int i = 1; i < argc; i++)
    {
        interpreter_argv[i] = argv[i];
    }

    interpreter_ptr interp_ptr = std::make_unique<interpreter>(argc, interpreter_argv.data());
    return interp_ptr;
}
```
This sets first arg and then passes all the args to ```xcpp::interpreter::interpreter```. But ```xcpp::interpreter::interpreter``` always skips the first arg(if the argv is non-null). 
```cpp
interpreter::interpreter(int argc, const char* const* argv) :
    xmagics()
    , p_cout_strbuf(nullptr)
    , p_cerr_strbuf(nullptr)
    , m_cout_buffer(std::bind(&interpreter::publish_stdout, this, _1))
    , m_cerr_buffer(std::bind(&interpreter::publish_stderr, this, _1))
{
    //NOLINTNEXTLINE (cppcoreguidelines-pro-bounds-pointer-arithmetic)
    createInterpreter(Args(argv ? argv + 1 : argv, argv + argc));
    m_version = get_stdopt();
    redirect_output();
    init_preamble();
    init_magic();
}
```

But, what if the argv is ``nullptr``??. It can happen if the user manually removes all the args from ``kernel.json``(including the program name). 
It can be show that if ``we are not passing any argument`` is same as ``we are passing only one argument``(i.e. the pgroam name). 
``createInterpreter(Args(nullptr, nullptr));`` is same as ``createInterpreter(Args(argv + 1, argv + 1));``.

#### Proof

<img width="1440" alt="Screenshot 2025-04-27 at 12 42 53 PM" src="https://github.com/user-attachments/assets/336064fa-f077-4bc7-9ba7-a3ba529d1795" />

