### PR TITLE
Add -s STRICT=1 flag emscripten build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,8 @@ if(EMSCRIPTEN)
         PUBLIC "SHELL: --preload-file ${XEUS_CPP_DATA_DIR}@/share/xeus-cpp"
         PUBLIC "SHELL: --preload-file ${XEUS_CPP_CONF_DIR}@/etc/xeus-cpp"
         PUBLIC "SHELL: --post-js ${CMAKE_CURRENT_SOURCE_DIR}/wasm_patches/post.js"
+        PUBLIC "SHELL: -s STRICT=1"
+        PUBLIC "SHELL: --no-entry"
     )
     # TODO: Uncomment the above line regarding preloading clang's resource dir
     # once has been supported through cppinterop.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,7 @@ if(EMSCRIPTEN)
         PUBLIC "SHELL: --preload-file ${SYSROOT_PATH}/include@/include"
         PUBLIC "SHELL: --preload-file ../${XEUS_CPP_DATA_DIR}@/share/xeus-cpp"
         PUBLIC "SHELL: --preload-file ../${XEUS_CPP_CONF_DIR}@/etc/xeus-cpp"
+        PUBLIC "SHELL: -s STRICT=1"
     )
 
     target_include_directories(test_xeus_cpp PRIVATE ${XEUS_CPP_INCLUDE_DIR})


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Taken from Emscripten documentation here https://emscripten.org/docs/tools_reference/settings_reference.html

```
Emscripten ‘strict’ build mode: Drop supporting any deprecated build options. Set the environment variable EMCC_STRICT=1 or pass -sSTRICT to test that a codebase builds nicely in forward compatible manner. Changes enabled by this:

        The C define EMSCRIPTEN is not defined (__EMSCRIPTEN__ always is, and is the correct thing to use).

        STRICT_JS is enabled.

        IGNORE_MISSING_MAIN is disabled.

        AUTO_JS_LIBRARIES is disabled.

        AUTO_NATIVE_LIBRARIES is disabled.

        DEFAULT_TO_CXX is disabled.

        USE_GLFW is set to 0 rather than 2 by default.

        ALLOW_UNIMPLEMENTED_SYSCALLS is disabled.

        INCOMING_MODULE_JS_API is set to empty by default.
```

Making sure the Emscripten build is done in such a way as to be forward compatible feels like a good feature to have.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
