### PR TITLE
Update wasm kernels & lite notebook to showcase latest development

### DIFF
--- a/notebooks/xeus-cpp-lite-demo.ipynb
+++ b/notebooks/xeus-cpp-lite-demo.ipynb
@@ -1,16 +1,16 @@
 {
   "metadata": {
     "kernelspec": {
-      "display_name": "C++20",
-      "language": "cpp",
-      "name": "xcpp20"
+      "name": "xcpp23",
+      "display_name": "C++23",
+      "language": "cpp"
     },
     "language_info": {
       "codemirror_mode": "text/x-c++src",
       "file_extension": ".cpp",
       "mimetype": "text/x-c++src",
       "name": "C++",
-      "version": "20"
+      "version": "23"
     }
   },
   "nbformat_minor": 5,
@@ -41,10 +41,10 @@
       "cell_type": "code",
       "source": "#include <iostream>\n\nstd::cout << \"some output\" << std::endl;",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
@@ -60,10 +60,10 @@
       "cell_type": "code",
       "source": "std::cerr << \"some error\" << std::endl;",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
@@ -75,14 +75,30 @@
       "execution_count": 2
     },
     {
+      "id": "c7dcdb89-6e0c-44a2-a968-d9fb9907deda",
+      "cell_type": "code",
+      "source": "#include <stdexcept>\n\ntry {\n    throw std::runtime_error(\"Unknown exception\");\n}\ncatch (const std::exception& e) {\n    std::cout << \"Caught an exception: \" << e.what() << std::endl;\n}",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": "Caught an exception: Unknown exception\n"
+        }
+      ],
+      "execution_count": 3
+    },
+    {
       "id": "7af0c962-17dc-47d4-9772-b8a06e2bda3a",
       "cell_type": "code",
       "source": "int j = 5;\nstd::cout << j << std::endl;",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
@@ -91,13 +107,17 @@
           "text": "5\n"
         }
       ],
-      "execution_count": 3
+      "execution_count": 4
     },
     {
-      "id": "526a7dba-4001-47d5-a116-95423118e100",
-      "cell_type": "markdown",
+      "id": "ccf81e76-507a-42e5-9f83-99793f0eb46c",
+      "cell_type": "code",
       "source": "# Interpreting the C++ programming language\n\nYou can define functions, classes, templates, etc ...",
-      "metadata": {}
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": null
     },
     {
       "id": "e5b116ce-ced1-4aa4-b14e-ef7d2606202e",
@@ -110,23 +130,23 @@
       "cell_type": "code",
       "source": "double sqr(double a)\n{\n    return a * a;\n}",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [],
-      "execution_count": 4
+      "execution_count": 5
     },
     {
       "id": "5aff6711-54bf-4280-a496-c9f7c683eee5",
       "cell_type": "code",
       "source": "double a = 2.5;\ndouble asqr = sqr(a);\nstd::cout << asqr << std::endl;",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
@@ -135,7 +155,7 @@
           "text": "6.25\n"
         }
       ],
-      "execution_count": 5
+      "execution_count": 6
     },
     {
       "id": "5b3959b0-9dc7-41a4-bba1-e20abd0765f7",
@@ -148,23 +168,23 @@
       "cell_type": "code",
       "source": "class Foo\n{\npublic:\n\n    virtual ~Foo() {}\n    \n    virtual void print(double value) const\n    {\n        std::cout << \"Foo value = \" << value << std::endl;\n    }\n};",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [],
-      "execution_count": 6
+      "execution_count": 7
     },
     {
       "id": "195d513f-d5cb-4e3d-a6cb-ae99dfcd9aab",
       "cell_type": "code",
       "source": "Foo bar;\nbar.print(1.2);",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
@@ -173,7 +193,7 @@
           "text": "Foo value = 1.2\n"
         }
       ],
-      "execution_count": 7
+      "execution_count": 8
     },
     {
       "id": "9ecc1588-cb6e-4676-bb16-b9938e980b06",
@@ -186,23 +206,23 @@
       "cell_type": "code",
       "source": "class Bar : public Foo\n{\npublic:\n\n    virtual ~Bar() {}\n    \n    virtual void print(double value) const\n    {\n        std::cout << \"Bar value = \" << 2 * value << std::endl;\n    }\n};",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [],
-      "execution_count": 8
+      "execution_count": 9
     },
     {
       "id": "f7dbbcc2-0f00-48eb-8bb9-94e871afa2a7",
       "cell_type": "code",
       "source": "Foo* bar2 = new Bar;\nbar2->print(1.2);\ndelete bar2;",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
@@ -211,7 +231,7 @@
           "text": "Bar value = 2.4\n"
         }
       ],
-      "execution_count": 9
+      "execution_count": 10
     },
     {
       "id": "094f4ca7-0aa5-4121-bfff-bf5db1d42c5d",
@@ -224,20 +244,23 @@
       "cell_type": "code",
       "source": "#include <typeinfo>\n\ntemplate <class T>\nclass FooT\n{\npublic:\n    \n    explicit FooT(const T& t) : m_t(t) {}\n    \n    void print() const\n    {\n        std::cout << typeid(T).name() << \" m_t = \" << m_t << std::endl;\n    }\n    \nprivate:\n    \n    T m_t;\n};",
       "metadata": {
+        "trusted": true,
         "vscode": {
           "languageId": "c++"
-        },
-        "trusted": true
+        }
       },
       "outputs": [],
-      "execution_count": 10
+      "execution_count": 11
     },
     {
       "id": "67181378-69d0-4adb-8a69-9abd20d3bc85",
       "cell_type": "code",
       "source": "FooT<double> foot(1.2);\nfoot.print();",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [
         {
@@ -246,7 +269,7 @@
           "text": "d m_t = 1.2\n"
         }
       ],
-      "execution_count": 11
+      "execution_count": 12
     },
     {
       "id": "6ce20171-18cb-4373-874b-89e6a2d2e425",
@@ -259,7 +282,10 @@
       "cell_type": "code",
       "source": "?std::vector",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [
         {
@@ -271,7 +297,7 @@
           "metadata": {}
         }
       ],
-      "execution_count": 12
+      "execution_count": 13
     },
     {
       "id": "afee187b-2e6a-47db-acb1-8dab5a975565",
@@ -300,37 +326,49 @@
       "cell_type": "code",
       "source": "#include <string>\n#include <fstream>\n#include <sstream>\n\n#include \"nlohmann/json.hpp\"\n\n#include \"xeus/xbase64.hpp\"\n\nnamespace nl = nlohmann;\n\nnamespace im\n{\n    struct image\n    {   \n        inline image(const std::string& filename)\n        {\n            std::ifstream fin(filename, std::ios::binary);   \n            m_buffer << fin.rdbuf();\n        }\n        \n        std::stringstream m_buffer;\n    };\n    \n    nl::json mime_bundle_repr(const image& i)\n    {\n        auto bundle = nl::json::object();\n        bundle[\"image/png\"] = xeus::base64encode(i.m_buffer.str());\n        return bundle;\n    }\n}",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [],
-      "execution_count": 13
+      "execution_count": 14
     },
     {
       "id": "b326166f-1652-4cd5-bc8e-e4fa93f848a6",
       "cell_type": "code",
       "source": "im::image marie(\"marie.png\");",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [],
-      "execution_count": 14
+      "execution_count": 15
     },
     {
       "id": "c32f5494-00e8-4427-bf6a-ce20c31ab44e",
       "cell_type": "code",
       "source": "#include \"xcpp/xdisplay.hpp\"",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [],
-      "execution_count": 15
+      "execution_count": 16
     },
     {
       "id": "fc494113-8283-4d27-93b1-055ce5ee8240",
       "cell_type": "code",
       "source": "xcpp::display(marie);",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [
         {
@@ -341,7 +379,7 @@
           "metadata": {}
         }
       ],
-      "execution_count": 16
+      "execution_count": 17
     },
     {
       "id": "b1c0a821-e794-4f31-a791-85536d997069",
@@ -354,27 +392,36 @@
       "cell_type": "code",
       "source": "namespace nl = nlohmann;\n\nnamespace au\n{\n    struct audio\n    {   \n        inline audio(const std::string& filename)\n        {\n            std::ifstream fin(filename, std::ios::binary);   \n            m_buffer << fin.rdbuf();\n        }\n        \n        std::stringstream m_buffer;\n    };\n    \n    nl::json mime_bundle_repr(const audio& a)\n    {\n        auto bundle = nl::json::object();\n        bundle[\"text/html\"] =\n           std::string(\"<audio controls=\\\"controls\\\"><source src=\\\"data:audio/wav;base64,\")\n           + xeus::base64encode(a.m_buffer.str()) +\n            \"\\\" type=\\\"audio/wav\\\" /></audio>\";\n        return bundle;\n    }\n}",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [],
-      "execution_count": 17
+      "execution_count": 18
     },
     {
       "id": "0cc2ee8f-955e-459a-847f-1729ea961710",
       "cell_type": "code",
       "source": "au::audio drums(\"audio.wav\");",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [],
-      "execution_count": 18
+      "execution_count": 19
     },
     {
       "id": "e4de8992-2ffa-4493-8d86-f3738b1f8e97",
       "cell_type": "code",
       "source": "xcpp::display(drums);",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [
         {
@@ -385,7 +432,7 @@
           "metadata": {}
         }
       ],
-      "execution_count": 19
+      "execution_count": 20
     },
     {
       "id": "f287b246-e1e2-4e5c-9167-89cd2b6b0de0",
@@ -398,17 +445,23 @@
       "cell_type": "code",
       "source": "namespace nl = nlohmann;\n\nnamespace ht\n{\n    struct html\n    {   \n        inline html(const std::string& content)\n        {\n            m_content = content;\n        }\n        std::string m_content;\n    };\n\n    nl::json mime_bundle_repr(const html& a)\n    {\n        auto bundle = nl::json::object();\n        bundle[\"text/html\"] = a.m_content;\n        return bundle;\n    }\n}\n\n// A blue rectangle\nht::html rect(R\"(\n<div style='\n    width: 90px;\n    height: 50px;\n    line-height: 50px;\n    background-color: blue;\n    color: white;\n    text-align: center;'>\nOriginal\n</div>)\");",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [],
-      "execution_count": 20
+      "execution_count": 21
     },
     {
       "id": "104f5359-2518-4a4c-bb79-b5b52041d745",
       "cell_type": "code",
       "source": "xcpp::display(rect, \"some_display_id\");",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [
         {
@@ -419,17 +472,20 @@
           "metadata": {}
         }
       ],
-      "execution_count": 21
+      "execution_count": 22
     },
     {
       "id": "8f6ab60e-eabf-4ecc-b856-a3e7f6b165b9",
       "cell_type": "code",
       "source": "// Update the rectangle to be red\nrect.m_content = R\"(\n<div style='\n    width: 90px;\n    height: 50px;\n    line-height: 50px;\n    background-color: red;\n    color: white;\n    text-align: center;'>\nUpdated\n</div>)\";\n\nxcpp::display(rect, \"some_display_id\", true);",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [],
-      "execution_count": 22
+      "execution_count": 23
     },
     {
       "id": "aa21443e-f927-4af1-b2ba-46ddd76dee65",
@@ -442,33 +498,23 @@
       "cell_type": "code",
       "source": "#include <chrono>\n#include <thread>",
       "metadata": {
-        "trusted": true
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
       },
       "outputs": [],
-      "execution_count": 23
+      "execution_count": 24
     },
     {
       "id": "7e05d371-633d-4419-95d1-29f77985859b",
       "cell_type": "code",
       "source": "std::cout << \"hello\" << std::endl;\nstd::this_thread::sleep_for(std::chrono::seconds(1));\nxcpp::clear_output();  // will flicker when replacing \"hello\" with \"goodbye\"\nstd::this_thread::sleep_for(std::chrono::seconds(1));\nstd::cout << \"goodbye\" << std::endl;",
       "metadata": {
-        "trusted": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": "goodbye\n"
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
         }
-      ],
-      "execution_count": 24
-    },
-    {
-      "id": "101ce1e3-9875-49ab-bf9b-e4e69ad4bf68",
-      "cell_type": "code",
-      "source": "std::cout << \"hello\" << std::endl;\nstd::this_thread::sleep_for(std::chrono::seconds(1));\nxcpp::clear_output(true);  // prevents flickering\nstd::this_thread::sleep_for(std::chrono::seconds(1));\nstd::cout << \"goodbye\" << std::endl;",
-      "metadata": {
-        "trusted": true
       },
       "outputs": [
         {
@@ -478,6 +524,67 @@
         }
       ],
       "execution_count": 25
+    },
+    {
+      "id": "101ce1e3-9875-49ab-bf9b-e4e69ad4bf68",
+      "cell_type": "code",
+      "source": "std::cout << \"hello\" << std::endl;\nstd::this_thread::sleep_for(std::chrono::seconds(1));\nxcpp::clear_output(true);  // prevents flickering\nstd::this_thread::sleep_for(std::chrono::seconds(1));\nstd::cout << \"goodbye\" << std::endl;",
+      "metadata": {
+        "trusted": true,
+        "vscode": {
+          "languageId": "c++"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": "goodbye\n"
+        }
+      ],
+      "execution_count": 26
+    },
+    {
+      "id": "4e69d1e7-3a55-4f91-8b82-15056ec0173e",
+      "cell_type": "markdown",
+      "source": "### SIMD Acceleration through WebAssembly Intrinsics\n\nExample inspired by https://emscripten.org/docs/porting/simd.html#webassembly-simd-intrinsics",
+      "metadata": {}
+    },
+    {
+      "id": "7a8d42ee-79a6-4b5c-8d79-35d688e40c17",
+      "cell_type": "code",
+      "source": "#include <wasm_simd128.h>\n#include <stdio.h>",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": 27
+    },
+    {
+      "id": "f6a65b84-ad63-455d-9704-a597b3b0f45c",
+      "cell_type": "code",
+      "source": "v128_t v1 = wasm_f32x4_make(1.2f, 3.4f, 5.6f, 7.8f);\nv128_t v2 = wasm_f32x4_make(2.1f, 4.3f, 6.5f, 8.7f);\n\nv128_t v3 = wasm_f32x4_add(v1, v2);\n\nprintf(\"v3: [%.1f, %.1f, %.1f, %.1f]\\n\",\n    wasm_f32x4_extract_lane(v3, 0),\n    wasm_f32x4_extract_lane(v3, 1),\n    wasm_f32x4_extract_lane(v3, 2),\n    wasm_f32x4_extract_lane(v3, 3));",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": "v3: [3.3, 7.7, 12.1, 16.5]\n"
+        }
+      ],
+      "execution_count": 28
+    },
+    {
+      "id": "4557f440-c441-4f25-b461-9b4769f882a1",
+      "cell_type": "code",
+      "source": "",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": null
     }
   ]
 }

--- a/share/jupyter/kernels/xcpp17/wasm_kernel.json.in
+++ b/share/jupyter/kernels/xcpp17/wasm_kernel.json.in
@@ -3,7 +3,8 @@
   "argv": [
       "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
       "-resource-dir", "/lib/clang/@CPPINTEROP_LLVM_VERSION_MAJOR@",
-      "-std=c++17"
+      "-std=c++17", "-mllvm", "-enable-emscripten-cxx-exceptions",
+      "-mllvm", "-enable-emscripten-sjlj", "-msimd128"
   ],
   "language": "cpp",
   "metadata": {

--- a/share/jupyter/kernels/xcpp20/wasm_kernel.json.in
+++ b/share/jupyter/kernels/xcpp20/wasm_kernel.json.in
@@ -3,7 +3,8 @@
   "argv": [
       "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
       "-resource-dir", "/lib/clang/@CPPINTEROP_LLVM_VERSION_MAJOR@",
-      "-std=c++20"
+      "-std=c++20", "-mllvm", "-enable-emscripten-cxx-exceptions",
+      "-mllvm", "-enable-emscripten-sjlj", "-msimd128"
   ],
   "language": "cpp",
   "metadata": {

--- a/share/jupyter/kernels/xcpp23/wasm_kernel.json.in
+++ b/share/jupyter/kernels/xcpp23/wasm_kernel.json.in
@@ -3,7 +3,8 @@
   "argv": [
       "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
       "-resource-dir", "/lib/clang/@CPPINTEROP_LLVM_VERSION_MAJOR@",
-      "-std=c++23"
+      "-std=c++23", "-mllvm", "-enable-emscripten-cxx-exceptions",
+      "-mllvm", "-enable-emscripten-sjlj", "-msimd128"
   ],
   "language": "cpp",
   "metadata": {


### PR DESCRIPTION
# Description

Additions to the wasm kernels

1) Adds flags inspired by https://github.com/compiler-research/CppInterOp/pull/543 to support exception handling
2) Add -msimd128 flag for any webassembly SIMD intrinsics 

should also allow us to run xsimd in xeus-cpp-lite

![image](https://github.com/user-attachments/assets/a154b5ca-b723-41ee-b749-1f7f22aa4dc9)
 


## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
