### PR TITLE
Fix the case where there is an @ in the absolute path of sysroot and XEUS_CPP_RESOURCE_DIR in Emscripten build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,6 +446,19 @@ if(EMSCRIPTEN)
     xeus_cpp_set_kernel_options(xcpp)
     xeus_wasm_compile_options(xcpp)
     xeus_wasm_link_options(xcpp "web,worker")
+    if (SYSROOT_PATH MATCHES "@")
+      execute_process(
+          COMMAND ln -s ${SYSROOT_PATH}
+      )
+      set(SYSROOT_PATH_ORIGINAL ${SYSROOT_PATH})
+      set(SYSROOT_PATH "./sysroot/")
+    endif()
+    if (XEUS_CPP_RESOURCE_DIR MATCHES "@")
+      execute_process(
+          COMMAND ln -s ${XEUS_CPP_RESOURCE_DIR}
+      )
+      set(XEUS_CPP_RESOURCE_DIR "./${CPPINTEROP_LLVM_VERSION_MAJOR}")
+    endif()
     target_link_options(xcpp
         PUBLIC "SHELL: -s USE_SDL=2"
         PUBLIC "SHELL: --preload-file ${SYSROOT_PATH}/include@/include"
@@ -460,6 +473,11 @@ endif()
 
 if(XEUS_CPP_BUILD_TESTS)
     add_subdirectory(test)
+    if (SYSROOT_PATH_ORIGINAL MATCHES "@")
+      execute_process(
+          COMMAND ln -s ${SYSROOT_PATH_ORIGINAL} "${CMAKE_CURRENT_BINARY_DIR}/test/"
+      )
+    endif()
 endif()
 
 # Installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,16 +446,12 @@ if(EMSCRIPTEN)
     xeus_cpp_set_kernel_options(xcpp)
     xeus_wasm_compile_options(xcpp)
     xeus_wasm_link_options(xcpp "web,worker")
-    if (SYSROOT_PATH MATCHES "@")
-       string(REPLACE "@" "@@" SYSROOT_PATH "${SYSROOT_PATH}")
-    endif()
-    if (XEUS_CPP_RESOURCE_DIR MATCHES "@")
-       string(REPLACE "@" "@@" XEUS_CPP_RESOURCE_DIR "${XEUS_CPP_RESOURCE_DIR}")
-    endif()
+    string(REPLACE "@" "@@" ESCAPED_SYSROOT_PATH "${SYSROOT_PATH}")
+    string(REPLACE "@" "@@" ESCAPED_XEUS_CPP_RESOURCE_DIR "${XEUS_CPP_RESOURCE_DIR}")
     target_link_options(xcpp
         PUBLIC "SHELL: -s USE_SDL=2"
-        PUBLIC "SHELL: --preload-file ${SYSROOT_PATH}/include@/include"
-        PUBLIC "SHELL: --preload-file ${XEUS_CPP_RESOURCE_DIR}@/${CMAKE_INSTALL_LIBDIR}/clang/${CPPINTEROP_LLVM_VERSION_MAJOR}"
+        PUBLIC "SHELL: --preload-file ${ESCAPED_SYSROOT_PATH}/include@/include"
+        PUBLIC "SHELL: --preload-file ${ESCAPED_XEUS_CPP_RESOURCE_DIR}@/${CMAKE_INSTALL_LIBDIR}/clang/${CPPINTEROP_LLVM_VERSION_MAJOR}"
         PUBLIC "SHELL: --preload-file ${XEUS_CPP_DATA_DIR}@/share/xeus-cpp"
         PUBLIC "SHELL: --preload-file ${XEUS_CPP_CONF_DIR}@/etc/xeus-cpp"
         PUBLIC "SHELL: --post-js ${CMAKE_CURRENT_SOURCE_DIR}/wasm_patches/post.js"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,17 +447,10 @@ if(EMSCRIPTEN)
     xeus_wasm_compile_options(xcpp)
     xeus_wasm_link_options(xcpp "web,worker")
     if (SYSROOT_PATH MATCHES "@")
-      execute_process(
-          COMMAND ln -s ${SYSROOT_PATH}
-      )
-      set(SYSROOT_PATH_ORIGINAL ${SYSROOT_PATH})
-      set(SYSROOT_PATH "./sysroot/")
+       string(REPLACE "@" "@@" SYSROOT_PATH "${SYSROOT_PATH}")
     endif()
     if (XEUS_CPP_RESOURCE_DIR MATCHES "@")
-      execute_process(
-          COMMAND ln -s ${XEUS_CPP_RESOURCE_DIR}
-      )
-      set(XEUS_CPP_RESOURCE_DIR "./${CPPINTEROP_LLVM_VERSION_MAJOR}")
+       string(REPLACE "@" "@@" XEUS_CPP_RESOURCE_DIR "${XEUS_CPP_RESOURCE_DIR}")
     endif()
     target_link_options(xcpp
         PUBLIC "SHELL: -s USE_SDL=2"
@@ -473,11 +466,6 @@ endif()
 
 if(XEUS_CPP_BUILD_TESTS)
     add_subdirectory(test)
-    if (SYSROOT_PATH_ORIGINAL MATCHES "@")
-      execute_process(
-          COMMAND ln -s ${SYSROOT_PATH_ORIGINAL} "${CMAKE_CURRENT_BINARY_DIR}/test/"
-      )
-    endif()
 endif()
 
 # Installation

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,7 +75,7 @@ if(EMSCRIPTEN)
         PUBLIC "SHELL: -s EXIT_RUNTIME=1"
         PUBLIC "SHELL: -s STACK_SIZE=32mb"
         PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
-        PUBLIC "SHELL: --preload-file ${SYSROOT_PATH}/include@/include"
+        PUBLIC "SHELL: --preload-file ${ESCAPED_SYSROOT_PATH}/include@/include"
         PUBLIC "SHELL: --preload-file ../${XEUS_CPP_DATA_DIR}@/share/xeus-cpp"
         PUBLIC "SHELL: --preload-file ../${XEUS_CPP_CONF_DIR}@/etc/xeus-cpp"
         PUBLIC "SHELL: --emrun"


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

I've been working around an issue with the Emscripten build for months locally. If your unlucky and happen to have a @ symbol in your absolute path for SYSROOT_PATH then it will get truncated at this point when preloading, and won't build. This recently got made worse by the introduction of XEUS_CPP_RESOURCE_DIR , which in my case also has an @ in the absolute path. This PR fixes this by creating a symlink in the build directory to these locations, avoiding a @ in the path.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
