### PR TITLE
Use mount instead of preload for tagfiles

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -143,6 +143,8 @@ jobs:
           micromamba activate xeus-lite-host
           jupyter lite build \
               --XeusAddon.prefix=${{ env.PREFIX }} \
+              --XeusAddon.mounts="${{ env.PREFIX }}/share/xeus-cpp/tagfiles:/share/xeus-cpp/tagfiles" \
+              --XeusAddon.mounts="${{ env.PREFIX }}/etc/xeus-cpp/tags.d:/etc/xeus-cpp/tags.d"
               --contents README.md \
               --contents notebooks/xeus-cpp-lite-demo.ipynb \
               --contents notebooks/smallpt.ipynb \

--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -144,7 +144,7 @@ jobs:
           jupyter lite build \
               --XeusAddon.prefix=${{ env.PREFIX }} \
               --XeusAddon.mounts="${{ env.PREFIX }}/share/xeus-cpp/tagfiles:/share/xeus-cpp/tagfiles" \
-              --XeusAddon.mounts="${{ env.PREFIX }}/etc/xeus-cpp/tags.d:/etc/xeus-cpp/tags.d"
+              --XeusAddon.mounts="${{ env.PREFIX }}/etc/xeus-cpp/tags.d:/etc/xeus-cpp/tags.d" \
               --contents README.md \
               --contents notebooks/xeus-cpp-lite-demo.ipynb \
               --contents notebooks/smallpt.ipynb \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,8 +450,6 @@ if(EMSCRIPTEN)
         PUBLIC "SHELL: -s USE_SDL=2"
         PUBLIC "SHELL: --preload-file ${SYSROOT_PATH}/include@/include"
         PUBLIC "SHELL: --preload-file ${XEUS_CPP_RESOURCE_DIR}@/${CMAKE_INSTALL_LIBDIR}/clang/${CPPINTEROP_LLVM_VERSION_MAJOR}"
-        PUBLIC "SHELL: --preload-file ${XEUS_CPP_DATA_DIR}@/share/xeus-cpp"
-        PUBLIC "SHELL: --preload-file ${XEUS_CPP_CONF_DIR}@/etc/xeus-cpp"
         PUBLIC "SHELL: --post-js ${CMAKE_CURRENT_SOURCE_DIR}/wasm_patches/post.js"
     )
 endif()


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Fixes #305 
Closes #295

As discussed on the issue 
1) xcpp.data should only be responsible for standard headers or resource dir headers
2) As tagfiles for any 3rd party lib would be expected to be picked up from the prefix, we should do the same for the tagfiles we provide.



## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
