### PR TITLE
Remove unused getDylinkMetadata in wasm_patches

### DIFF
--- a/wasm_patches/post.js
+++ b/wasm_patches/post.js
@@ -5,7 +5,6 @@ if (!('wasmTable' in Module)) {
 Module.FS = FS
 Module.PATH = PATH
 Module.LDSO = LDSO
-Module.getDylinkMetadata = getDylinkMetadata
 Module.loadDynamicLibrary = loadDynamicLibrary
 
 Module.UTF8ToString = UTF8ToString;


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

If you look here https://github.com/compiler-research/xeus-cpp/actions/runs/15491557309/job/43618050719#step:5:192 , you'll see that the Emscripten build of xeus-cpp has the following warning

warning: invalid item in EXPORTED_RUNTIME_METHODS: getDylinkMetadata

This means we are not using this part of the wasm_patches, so can be removed.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
