### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ bld
 # LLM Implementation
 *_api_key.txt
 *_chat_history.txt
+
+# MacOS specific files
+*.DS_Store


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

While trying something out earlier I noticed xeus-cpp picked up the creation of a .DS_Store . On projects I work on this file is usually added to the .gitignore, so it isn't accidentally picked up . This PR does this.

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
