### PR TITLE
Add missing backslash jupyter build command in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ To build Jupyter Lite with this kernel without creating a website you can execut
 ```bash
 micromamba create -n xeus-lite-host jupyterlite-core=0.6 jupyter_server jupyterlite-xeus -c conda-forge
 micromamba activate xeus-lite-host
-jupyter lite build --XeusAddon.prefix=$PREFIX
+jupyter lite build --XeusAddon.prefix=$PREFIX \
                    --XeusAddon.mounts="$PREFIX/share/xeus-cpp/tagfiles:/share/xeus-cpp/tagfiles" \
                    --XeusAddon.mounts="$PREFIX/etc/xeus-cpp/tags.d:/etc/xeus-cpp/tags.d" \
                    --contents README.md \

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To build Jupyter Lite with this kernel without creating a website you can execut
 ```bash
 micromamba create -n xeus-lite-host jupyterlite-core=0.6 jupyter_server jupyterlite-xeus -c conda-forge
 micromamba activate xeus-lite-host
-jupyter lite build --XeusAddon.prefix=$PREFIX               
+jupyter lite build --XeusAddon.prefix=$PREFIX \            
                    --XeusAddon.mounts="$PREFIX/share/xeus-cpp/tagfiles:/share/xeus-cpp/tagfiles" \
                    --XeusAddon.mounts="$PREFIX/etc/xeus-cpp/tags.d:/etc/xeus-cpp/tags.d" \
                    --contents README.md \


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

In https://github.com/compiler-research/xeus-cpp/pull/343 I missed a backslash in 2 locations for the jupyter build command. This PR fixes that.

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [x] Required documentation updates
