### PR TITLE
Revert https://github.com/compiler-research/xeus-cpp/pull/349 (keeping test)

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -73,20 +73,31 @@ namespace xcpp
         xeus::register_interpreter(this);
     }
 
-    static std::string get_stdopt(int argc, const char* const* argv)
+    static std::string get_stdopt()
     {
-        std::string res = "14";
-        for (int i = 0; i < argc; ++i)
-        {
-            std::string arg(argv[i]);
-            auto pos = arg.find("-std=c++");
-            if (pos != std::string::npos)
-            {
-                res = arg.substr(pos + 8);
-                break;
-            }
-        }
-        return res;
+        // We need to find what's the C++ version the interpreter runs with.
+        const char* code = R"(
+int __get_cxx_version () {
+#if __cplusplus > 202302L
+    return 26;
+#elif __cplusplus > 202002L
+    return 23;
+#elif __cplusplus >  201703L
+    return 20;
+#elif __cplusplus > 201402L
+    return 17;
+#elif __cplusplus > 201103L || (defined(_WIN32) && _MSC_VER >= 1900)
+    return 14;
+#elif __cplusplus >= 201103L
+   return 11;
+#else
+  return 0;
+#endif
+  }
+__get_cxx_version ()
+      )";
+        auto cxx_version = Cpp::Evaluate(code);
+        return std::to_string(cxx_version);
     }
 
     interpreter::interpreter(int argc, const char* const* argv) :
@@ -98,7 +109,7 @@ namespace xcpp
     {
         //NOLINTNEXTLINE (cppcoreguidelines-pro-bounds-pointer-arithmetic)
         createInterpreter(Args(argv ? argv + 1 : argv, argv + argc));
-        m_version = get_stdopt(argc, argv);
+        m_version = get_stdopt();
         redirect_output();
         init_preamble();
         init_magic();


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

Currently CppInterOps Emscripten ci is broken to https://github.com/compiler-research/xeus-cpp/pull/349 for MacOS arm for llvm, as can be seen here https://github.com/compiler-research/CppInterOp/actions/runs/15633230695 .
The test itself passes in these circumstances with the old get_stdopt as can be seen here https://github.com/compiler-research/CppInterOp/pull/632 . Therefore this PR suggests reverting get_stdopt while keeping the test


## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
