### PR TITLE
Improve doctest output

### DIFF
--- a/test/main.cpp
+++ b/test/main.cpp
@@ -6,5 +6,20 @@
  * The full license is in the file LICENSE, distributed with this software.
  ****************************************************************************/
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_IMPLEMENT
 #include "doctest/doctest.h"
+
+int main(int argc, char** argv) {
+    doctest::Context context;
+
+    // Set options to show more detailed test output
+    context.setOption("success", true);
+    context.setOption("report-failures", true);
+    context.setOption("force-colors", true);
+    
+    context.applyCommandLine(argc, argv);
+
+    int res = context.run();
+
+    return res;
+}


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Currently the output from doctest isn't very useful, as it only gives a number of how many tests pass and fail at the end, and not a list of which tests fail (see image below). It is also hard to disentangle which output to the terminal is from which tests.
![image](https://github.com/user-attachments/assets/76f6ef73-8dd2-4171-8383-f9d58465189f)

This PR fixes this by providing a custom doctest config, where we pass specific command line arguments to doctest via the method outlined in doctests documentation (see https://github.com/doctest/doctest/blob/master/doc/markdown/main.md )

In the case of the browser tests that xeus-cpp has, this is the only way to pass these command line arguments. 

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
