### PR TITLE
Remove duplicate EXIT_RUNTIME flag (--emrun turns this flag on)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,7 +72,6 @@ if(EMSCRIPTEN)
         PUBLIC "SHELL: -s WASM_BIGINT"
         PUBLIC "SHELL: -s ASSERTIONS=0"
         PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
-        PUBLIC "SHELL: -s EXIT_RUNTIME=1"
         PUBLIC "SHELL: -s STACK_SIZE=32mb"
         PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
         PUBLIC "SHELL: --preload-file ${ESCAPED_SYSROOT_PATH}/include@/include"


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

If you look at the description of emscriptens --emrun flag here https://emscripten.org/docs/tools_reference/emcc.html  (search --emrun), you'll see that it enables EXIT_RUNTIME=1 . Therefore including it as a flag for the test executable is a duplication that can be removed.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
