### PR TITLE
Enable Windows Emscripten build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,11 +432,8 @@ endif()
 
 if(EMSCRIPTEN)
     # Ensure required SDL2 ports (e.g. SDL2) are built before header preloading
-    if (CMAKE_C_COMPILER MATCHES ".bat")
-      set(embuilder_suffix .bat)
-    endif()
     execute_process(
-        COMMAND embuilder${embuilder_suffix} build sdl2
+        COMMAND embuilder${EMCC_SUFFIX} build sdl2
         RESULT_VARIABLE SDL2_RESULT
     )
     if(NOT SDL2_RESULT EQUAL 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,8 +432,11 @@ endif()
 
 if(EMSCRIPTEN)
     # Ensure required SDL2 ports (e.g. SDL2) are built before header preloading
+    if (CMAKE_C_COMPILER MATCHES ".bat")
+      set(embuilder_suffix .bat)
+    endif()
     execute_process(
-        COMMAND embuilder build sdl2
+        COMMAND embuilder${embuilder_suffix} build sdl2
         RESULT_VARIABLE SDL2_RESULT
     )
     if(NOT SDL2_RESULT EQUAL 0)
@@ -448,6 +451,8 @@ if(EMSCRIPTEN)
     xeus_wasm_link_options(xcpp "web,worker")
     string(REPLACE "@" "@@" ESCAPED_SYSROOT_PATH "${SYSROOT_PATH}")
     string(REPLACE "@" "@@" ESCAPED_XEUS_CPP_RESOURCE_DIR "${XEUS_CPP_RESOURCE_DIR}")
+    string(REPLACE "\\" "/" ESCAPED_XEUS_CPP_RESOURCE_DIR "${ESCAPED_XEUS_CPP_RESOURCE_DIR}")
+    string(REPLACE "\\" "/" ESCAPED_SYSROOT_PATH "${ESCAPED_SYSROOT_PATH}")
     target_link_options(xcpp
         PUBLIC "SHELL: -s USE_SDL=2"
         PUBLIC "SHELL: --preload-file ${ESCAPED_SYSROOT_PATH}/include@/include"


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR enable xeus-cpp to be cross compiled to Emscripten on a Windows platform (following Emscripten build instructions in CppInterOp). The 2 changes are as follows

1) Add .bat suffix to embuilder if on Windows (otherwise it uses the one made for Unix systems and errors)
2)  Change \ to / in ESCAPED_XEUS_CPP_RESOURCE_DIR and  ESCAPED_SYSROOT_PATH (\ gets removed from the preloaded path otherwise)

To see these changing allow an Emscripten build of xeus-cpp to work and pass all Emscripten tests, see this PR in CppInterOp https://github.com/compiler-research/CppInterOp/pull/647

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
