### PR TITLE
Move MacOS x86 runners to MacOS 15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,8 @@ jobs:
           - name: ubu22-arm
             os: ubuntu-22.04-arm
             micromamba_shell_init: bash
-          - name: osx13-x86
-            os: macos-13
+          - name: osx15-x86
+            os: macos-15-intel
             micromamba_shell_init: bash
           - name: osx14-arm
             os: macos-14


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

The MacOS 13 x86 runners have just been deprecated (see https://github.com/actions/runner-images/issues/13046) and a MacOS 15 x86 runner has been created as a replacement (see https://github.com/actions/runner-images/issues/13045). This will be the final MacOS x86 Github runner.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
