### PR TITLE
[ci] Remove reference to llvm-project in coverage report preparation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,7 +171,7 @@ jobs:
           sudo apt install lcov
           # capture coverage info
           lcov --directory build/ --capture --output-file coverage.info --gcov-tool $CONDA_PREFIX/bin/gcov
-          lcov --remove coverage.info '/usr/*' "${HOME}"'/.cache/*' ${{ github.workspace }}'/llvm-project/*' ${{ github.workspace }}'/test/*' --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' "${HOME}"'/.cache/*' ${{ github.workspace }}'/test/*' --output-file coverage.info
           # output coverage data for debugging (optional)
           lcov --list coverage.info
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

There is no reason for the llvm-project to be mentioned in the coverage report preparation. This PR removes it.  

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
