### PR TITLE
Remove unneeded c++ versions in get_stdopt

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -86,10 +86,6 @@ int __get_cxx_version () {
     return 20;
 #elif __cplusplus > 201402L
     return 17;
-#elif __cplusplus > 201103L || (defined(_WIN32) && _MSC_VER >= 1900)
-    return 14;
-#elif __cplusplus >= 201103L
-   return 11;
 #else
   return 0;
 #endif


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

We don't support c++11 or c++14 kernels anymore, so these lines are unneeded

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
