### PR TITLE
Fix README.md (``` accidentallty left in https://github.com/compiler-research/xeus-cpp/pull/408)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ cd ../test
 pytest -sv test_xcpp_kernel.py
 ```
 to perform the python tests.
-```
 
 ## Installation within a mamba environment (wasm build instructions)
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

After https://github.com/compiler-research/xeus-cpp/pull/408 went in I realised I accidentally missed a  ``` which needed removing from the readme. I checked the contributing.md and readthedocs file and they were fine. Its just the readme that got missed
This PR changes this in xeus-cpps README.md
<img width="1714" height="436" alt="image" src="https://github.com/user-attachments/assets/dd338f72-9a0e-4da2-8e17-36fd939d0a70" />
to
<img width="1714" height="436" alt="image" src="https://github.com/user-attachments/assets/3fe0d807-a65e-4392-bb49-420a0e6c2d5e" />

