### PR TITLE
Fix formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ cd ../test
 pytest -sv test_xcpp_kernel.py
 ```
 to perform the python tests.
-```
 
 ## Installation within a mamba environment (wasm build instructions)
 


### PR DESCRIPTION
These extra backticks break the intended formatting. Currently we see:

```
## Installation within a mamba environment (wasm build instructions)

These instructions will assume you have cmake installed on your system. First clone the repository, and move into that directory
```bash
git clone --depth=1 https://github.com/compiler-research/xeus-cpp.git
cd ./xeus-cpp
```