### PR TITLE
Pin setup-micromamba action to v2

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: install mamba
-        uses: mamba-org/setup-micromamba@main
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment-wasm-build.yml
           init-shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 0
 
       - name: install mamba
-        uses: mamba-org/setup-micromamba@main
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment-dev.yml
           init-shell: >-
@@ -211,7 +211,7 @@ jobs:
           fetch-depth: 0
 
       - name: install mamba
-        uses: mamba-org/setup-micromamba@main
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment-wasm-build.yml
           init-shell: bash


### PR DESCRIPTION
The Github action setup-micromamba is currently set to be the main version. It should really be pinned for a particular version. Looking at xeus-r and xeus-python, they are fixed to v2, so this PR pins the action to v2 improving consistency between the xeus repos.