### PR TITLE
Update xeus-cpp to CppInterOp 1.8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,6 @@ jobs:
           - name: osx15-x86
             os: macos-15-intel
             micromamba_shell_init: bash
-          - name: osx14-arm
-            os: macos-14
-            micromamba_shell_init: bash
           - name: osx15-arm
             os: macos-15
             micromamba_shell_init: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ endif()
 
 set(xeus_REQUIRED_VERSION 5.0.0)
 set(xeus_zmq_REQUIRED_VERSION 3.0.0)
-set(CppInterOp_REQUIRED_VERSION 1.7.0)
+set(CppInterOp_REQUIRED_VERSION 1.8.0)
 set(xeus_lite_REQUIRED_VERSION 3.2.1)
 
 if (NOT TARGET xeus AND NOT TARGET xeus-static)

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ http://xeus-cpp.readthedocs.io
 
 | `xeus-cpp` | `xeus-zmq`      | `CppInterOp` | `pugixml` | `cpp-argparse`| `nlohmann_json` |
 |------------|-----------------|--------------|-----------|---------------|-----------------|
-|  main      |  3.1.0 | 1.7.0      | 1.15    | 3.2    | 3.12.0   |
+|  main      |  3.1.0 | 1.8.0      | 1.15    | 3.2    | 3.12.0   |
 
 ## Contributing
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,13 +5,13 @@ dependencies:
   # Build dependencies
   - make
   - cmake
-  - cxx-compiler=1.7.0
+  - cxx-compiler
   # Host dependencies
   - xeus>=5.0.0
   - xeus-zmq<4.0
   - nlohmann_json
   - nlohmann_json-abi
-  - CppInterOp
+  - CppInterOp>1.7.0
   - pugixml
   - cpp-argparse
   # Test dependencies

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -7,7 +7,7 @@ dependencies:
   - nlohmann_json-abi
   - xeus-lite
   - xeus
-  - CppInterOp
+  - CppInterOp>1.7.0
   - cpp-argparse
   - pugixml
   - doctest

--- a/include/xeus-cpp/xinterpreter.hpp
+++ b/include/xeus-cpp/xinterpreter.hpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-#include "clang/Interpreter/CppInterOp.h" // from CppInterOp package
+#include <CppInterOp/CppInterOp.h>
 
 #include <nlohmann/json.hpp>
 

--- a/src/xinspect.cpp
+++ b/src/xinspect.cpp
@@ -14,7 +14,7 @@
 
 #include "xinspect.hpp"
 
-#include "clang/Interpreter/CppInterOp.h"
+#include <CppInterOp/CppInterOp.h>
 
 namespace xcpp
 {


### PR DESCRIPTION
This PR gets xeus-cpp ready for the impending release of CppInterOp.

Fixes #186 