### PR TITLE
Drop -march=native being a default flag when building xeus-cpp

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,10 +30,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES Clang OR CMAKE_CXX_COMPILER_ID MATCHES GNU OR C
         add_compile_options(-Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion)
     endif()
 
-    CHECK_CXX_COMPILER_FLAG(-march=native HAS_MARCH_NATIVE)
-    if (HAS_MARCH_NATIVE)
-        add_compile_options(-march=native)
-    endif()
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)


### PR DESCRIPTION
When building xeus-cpp `-march=native` shouldn't be a default flag, due to cases where xeus-cpp is cross compiled from one platform for a different platform. For example the osx 86 conda-forge package is built on a osx arm platform.