### PR TITLE
Reduce initial memory when building xeus-cpp tests to 64Mb

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,7 +69,7 @@ if(EMSCRIPTEN)
         PUBLIC "SHELL: -s ASSERTIONS=0"
         PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
         PUBLIC "SHELL: -s STACK_SIZE=32mb"
-        PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
+        PUBLIC "SHELL: -s INITIAL_MEMORY=64MB"
         PUBLIC "SHELL: --preload-file ${ESCAPED_SYSROOT_PATH}/include@/include"
         PUBLIC "SHELL: --preload-file ../${XEUS_CPP_DATA_DIR}@/share/xeus-cpp"
         PUBLIC "SHELL: --preload-file ../${XEUS_CPP_CONF_DIR}@/etc/xeus-cpp"


### PR DESCRIPTION
xeus recently changed its initial memory flag to 32 Mb (here https://github.com/jupyter-xeus/xeus/pull/440/changes). This PR changes xeus-cpp to match. 