### PR TITLE
Catch node failures in ci

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Build and test xeus-cpp in node, then install
         shell: bash -l {0}
         run: |
+          set -e
           micromamba create -f environment-wasm-host.yml \
           --platform=emscripten-wasm32 \
           -c https://prefix.dev/emscripten-forge-4x \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,6 +227,7 @@ jobs:
       - name: Build and test xeus-cpp in node, then install
         shell: bash -l {0}
         run: |
+          set -e
           micromamba create -f environment-wasm-host.yml \
           --platform=emscripten-wasm32 \
           -c https://prefix.dev/emscripten-forge-4x \


### PR DESCRIPTION
When we was experimenting with reducing the initial memory when creating the xeus-cpp tests, the node tests failed to run, but the ci didn't catch it and fail (see https://github.com/compiler-research/xeus-cpp/actions/runs/21941897688/job/63369501220#step:5:182). This PR will attempt to catch these failures, and once they are caught the cmake change will be reverted.