### PR TITLE
Run tests under Valgrind on Ubuntu arm in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,10 @@ jobs:
             coverage: true
             debug: on
             micromamba_shell_init: bash
+          - name: ubu24-arm-analyzers
+            os: ubuntu-24.04-arm
+            debug: on
+            micromamba_shell_init: bash
           - name: ubu22
             os: ubuntu-22.04
             micromamba_shell_init: bash
@@ -137,10 +141,15 @@ jobs:
               sudo apt update
               sudo apt install libc6-dbg
               micromamba install -c conda-forge valgrind
+              if [[ "${{ matrix.os }}" == *"arm"* ]]; then
+                SUPPRESSION_FILE="${{ github.workspace }}/etc/xeus-cpp-valgrind_arm.supp"
+              else
+                SUPPRESSION_FILE="${{ github.workspace }}/etc/xeus-cpp-valgrind_x86.supp"
+              fi
               valgrind --show-error-list=yes --track-origins=yes --error-exitcode=1 \
                 --show-leak-kinds=definite,possible \
                 --gen-suppressions=all \
-                --suppressions="../etc/xeus-cpp-valgrind_x86.supp" \
+                --suppressions="${SUPPRESSION_FILE}" \
                 test/test_xeus_cpp
           fi
 

--- a/etc/xeus-cpp-valgrind_arm.supp
+++ b/etc/xeus-cpp-valgrind_arm.supp
@@ -1,0 +1,76 @@
+{
+   Suppression 1
+   Memcheck:Overlap
+   fun:__GI_memcpy
+   fun:copy
+   fun:_S_copy
+   fun:_S_copy
+   fun:_S_copy_chars
+   fun:_S_copy_chars
+   fun:_M_construct<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:basic_string<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:str
+   fun:operator std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >::string_type
+   fun:_ZN4xcpp11interpreter20inspect_request_implERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEii
+   fun:_ZN4xeus12xinterpreter15inspect_requestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEii
+   fun:_ZN21DOCTEST_ANON_SUITE_11L20DOCTEST_ANON_FUNC_12Ev
+   fun:_ZN7doctest7Context3runEv
+   fun:main
+}
+{
+   Suppression 2
+   Memcheck:Addr8
+   fun:__GI_memcpy
+   fun:copy
+   fun:_S_copy
+   fun:_S_copy
+   fun:_S_copy_chars
+   fun:_S_copy_chars
+   fun:_M_construct<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:basic_string<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:str
+   fun:operator std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >::string_type
+   fun:_ZN4xcpp11interpreter20inspect_request_implERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEii
+   fun:_ZN4xeus12xinterpreter15inspect_requestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEii
+   fun:_ZN21DOCTEST_ANON_SUITE_11L20DOCTEST_ANON_FUNC_14Ev
+   fun:_ZN7doctest7Context3runEv
+   fun:main
+}
+{
+   Suppression 3
+   Memcheck:Addr2
+   fun:__GI_memcpy
+   fun:copy
+   fun:_S_copy
+   fun:_S_copy
+   fun:_S_copy_chars
+   fun:_S_copy_chars
+   fun:_M_construct<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:basic_string<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:str
+   fun:operator std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >::string_type
+   fun:_ZN4xcpp11interpreter20inspect_request_implERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEii
+   fun:_ZN4xeus12xinterpreter15inspect_requestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEii
+   fun:_ZN21DOCTEST_ANON_SUITE_11L20DOCTEST_ANON_FUNC_14Ev
+   fun:_ZN7doctest7Context3runEv
+   fun:main
+}
+{
+   Suppression 4
+   Memcheck:Addr1
+   fun:__GI_memcpy
+   fun:copy
+   fun:_S_copy
+   fun:_S_copy
+   fun:_S_copy_chars
+   fun:_S_copy_chars
+   fun:_M_construct<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:basic_string<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:str
+   fun:operator std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >::string_type
+   fun:_ZN4xcpp11interpreter20inspect_request_implERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEii
+   fun:_ZN4xeus12xinterpreter15inspect_requestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEii
+   fun:_ZN21DOCTEST_ANON_SUITE_11L20DOCTEST_ANON_FUNC_14Ev
+   fun:_ZN7doctest7Context3runEv
+   fun:main
+}


### PR DESCRIPTION
In https://github.com/compiler-research/xeus-cpp/pull/405 the tests were run under Valgrind on the Ubuntu x86 runner. The tests couldn't be run under Valgrind on the Ubuntu arm due to a illegal instruction error. This was due to the `-march=native` flag removed in https://github.com/compiler-research/xeus-cpp/pull/443 . With this flag removed the tests under Valgrind on Ubuntu arm in the ci too.