### PR TITLE
Remove need for XEUS_CPP_EMSCRIPTEN_WASM_BUILD and use __EMSCRIPTEN__ preprocessor instead

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -63,7 +63,6 @@ jobs:
           emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
-            -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
             -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
             -DSYSROOT_PATH=$SYSROOT_PATH                      \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=ON               \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,7 +245,6 @@ jobs:
           emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release                        \
             -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
-            -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
             -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
             -DSYSROOT_PATH=$SYSROOT_PATH                      \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=ON               \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ option(XEUS_CPP_BUILD_EXECUTABLE "Build the xcpp executable" ON)
 
 option(XEUS_CPP_USE_SHARED_XEUS "Link xcpp with the xeus shared library (instead of the static library)" ON)
 option(XEUS_CPP_USE_SHARED_XEUS_CPP "Link xcpp with the xeus-cpp shared library (instead of the static library)" ON)
-option(XEUS_CPP_EMSCRIPTEN_WASM_BUILD "Build for wasm with emscripten" OFF)
 
 # Test options
 option(XEUS_CPP_BUILD_TESTS "xeus-cpp test suite" ON)
@@ -75,7 +74,6 @@ if(XEUS_CPP_ENABLE_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 endif()
 
 if(EMSCRIPTEN)
-    add_compile_definitions(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
     message("Build with emscripten")
     set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
     set(XEUS_CPP_BUILD_SHARED OFF)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,6 @@ export SYSROOT_PATH=$BUILD_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 emcmake cmake \
         -DCMAKE_BUILD_TYPE=Release                        \
         -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
-        -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
         -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
         -DSYSROOT_PATH=$SYSROOT_PATH                      \
         ..

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ export SYSROOT_PATH=$BUILD_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot
 emcmake cmake \
         -DCMAKE_BUILD_TYPE=Release                        \
         -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
-        -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
         -DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
         -DSYSROOT_PATH=$SYSROOT_PATH                      \
         ..

--- a/docs/source/InstallationAndUsage.rst
+++ b/docs/source/InstallationAndUsage.rst
@@ -84,7 +84,6 @@ You are now in a position to build the xeus-cpp kernel. You build and test it in
     emcmake cmake \
 		-DCMAKE_BUILD_TYPE=Release                        \
 		-DCMAKE_INSTALL_PREFIX=$PREFIX                    \
-		-DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
 		-DCMAKE_FIND_ROOT_PATH=$PREFIX                    \
 		-DSYSROOT_PATH=$SYSROOT_PATH                      \
 		..

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,6 @@ export SYSROOT_PATH=$BUILD_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot;
 emcmake cmake -DCMAKE_BUILD_TYPE=Release \\
               -DCMAKE_PREFIX_PATH=$PREFIX \\
               -DCMAKE_INSTALL_PREFIX=$PREFIX \\
-              -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON \\
               -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON \\
               -DSYSROOT_PATH=$SYSROOT_PATH \\
               {XEUS_CPP_ROOT};

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -19,7 +19,7 @@
 #include "xinspect.hpp"
 #include "xmagics/os.hpp"
 #include <iostream>
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 #include "xmagics/xassist.hpp"
 #endif
 #include "xparser.hpp"
@@ -372,7 +372,7 @@ __get_cxx_version ()
         // timeit(&m_interpreter));
         // preamble_manager["magics"].get_cast<xmagics_manager>().register_magic("python", pythonexec());
         preamble_manager["magics"].get_cast<xmagics_manager>().register_magic("file", writefile());
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
         preamble_manager["magics"].get_cast<xmagics_manager>().register_magic("xassist", xassist());
 #endif
     }

--- a/src/xutils.cpp
+++ b/src/xutils.cpp
@@ -15,7 +15,7 @@
 
 #ifdef __GNUC__
 #include <stdio.h>
-#ifndef XEUS_CPP_EMSCRIPTEN_WASM_BUILD
+#ifndef __EMSCRIPTEN__
 #include <execinfo.h>
 #endif
 #include <stdlib.h>
@@ -30,7 +30,7 @@
 namespace xcpp
 {
 
-#if defined(__GNUC__) && !defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+#if defined(__GNUC__) && !defined(__EMSCRIPTEN__)
     void handler(int sig)
     {
         void* array[10];

--- a/test/test_interpreter.cpp
+++ b/test/test_interpreter.cpp
@@ -27,7 +27,7 @@
 #include <iostream>
 #include <pugixml.hpp>
 #include <fstream>
-#if defined(__GNUC__) && !defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+#if defined(__GNUC__) && !defined(__EMSCRIPTEN__)
     #include <sys/wait.h>
     #include <unistd.h>
 #endif
@@ -102,7 +102,7 @@ TEST_SUITE("execute_request")
         REQUIRE(result["status"] == "ok");
     }
 
-#if defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+#if defined(__EMSCRIPTEN__)
     TEST_CASE("headers found in sysroot/include/compat")
     {
         std::vector<const char*> Args = {
@@ -139,7 +139,7 @@ TEST_SUITE("execute_request")
     }
 #endif
 
-#if defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+#if defined(__EMSCRIPTEN__)
     TEST_CASE("Emscripten Exception Handling")
     {
         std::vector<const char*> Args = {
@@ -286,7 +286,7 @@ TEST_SUITE("execute_request")
 
 TEST_SUITE("inspect_request")
 {
-#if defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+#if defined(__EMSCRIPTEN__)
     TEST_CASE("good_status"
             * doctest::should_fail(true)
             * doctest::description("TODO: Currently fails for the Emscripten build"))
@@ -719,7 +719,7 @@ TEST_SUITE("xsystem_clone")
     }
 }
 
-#if !defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+#if !defined(__EMSCRIPTEN__)
 TEST_SUITE("xsystem_apply")
 {
     TEST_CASE("apply_xsystem")
@@ -829,7 +829,7 @@ TEST_SUITE("xmagics_apply"){
     }
 }
 
-#if defined(__GNUC__) && !defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+#if defined(__GNUC__) && !defined(__EMSCRIPTEN__)
 TEST_SUITE("xutils_handler"){
     TEST_CASE("handler") {
         pid_t pid = fork();
@@ -963,7 +963,7 @@ TEST_SUITE("xinspect"){
 
 }
 
-#if !defined(XEUS_CPP_EMSCRIPTEN_WASM_BUILD)
+#if !defined(__EMSCRIPTEN__)
 TEST_SUITE("xassist"){
 
     TEST_CASE("model_not_found"){

--- a/xeus-cppConfig.cmake.in
+++ b/xeus-cppConfig.cmake.in
@@ -21,7 +21,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
 @XEUS_CPP_CONFIG_CODE@
 
 include(CMakeFindDependencyMacro)
-if (NOT @XEUS_CPP_EMSCRIPTEN_WASM_BUILD@)
+if (NOT EMSCRIPTEN)
     find_dependency(xeus-zmq @xeus-zmq_REQUIRED_VERSION@)
 endif ()
 


### PR DESCRIPTION
I've never understood the need to have a compile defintion of XEUS_CPP_EMSCRIPTEN_WASM_BUILD. When building with Emscripten your guaranteed the pre processor of \_\_EMSCRIPTEN\_\_ defined (see here https://emscripten.org/docs/compiling/Building-Projects.html#detecting-emscripten-in-preprocessor), so I think its better to just use that and drop the cmake option.