### PR TITLE
Account for change of name of CppInterOp target (clangCppInterOp to CppInterOp)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,13 @@ if (NOT TARGET xeus AND NOT TARGET xeus-static)
 endif ()
 
 find_package(CppInterOp ${CppInterOp_REQUIRED_VERSION} REQUIRED)
+
+# Extract filename without extension
+get_filename_component(_name "${CPPINTEROP_LIBRARIES}" NAME_WE)
+
+# Remove "lib" prefix
+string(REGEX REPLACE "^lib" "" CPPINTEROP_TARGET "${_name}")
+
 if(CppInterOp_FOUND)
   message(STATUS "Found CppInterOp: config=${CPPINTEROP_CMAKE_DIR} dir=${CPPINTEROP_INSTALL_PREFIX} (found version=${CPPINTEROP_VERSION} compatible with Clang ${CPPINTEROP_LLVM_VERSION_MAJOR}.x)")
 endif()
@@ -339,7 +346,7 @@ macro(xeus_cpp_create_target target_name linkage output_name)
         endif()
 
         # Existing target_link_libraries call, adjusted for clarity
-        target_link_libraries(${target_name} PUBLIC ${XEUS_CPP_XEUS_TARGET} clangCppInterOp pugixml argparse::argparse)
+        target_link_libraries(${target_name} PUBLIC ${XEUS_CPP_XEUS_TARGET} ${CPPINTEROP_TARGET}  pugixml argparse::argparse)
 
         # Ensure all linked libraries use the same runtime library
         if (MSVC)
@@ -360,9 +367,9 @@ macro(xeus_cpp_create_target target_name linkage output_name)
         endif()
 
         # Curl initialised specifically for xassist
-        target_link_libraries(${target_name} PUBLIC ${XEUS_CPP_XEUS_TARGET} clangCppInterOp pugixml argparse::argparse CURL::libcurl)
+        target_link_libraries(${target_name} PUBLIC ${XEUS_CPP_XEUS_TARGET} ${CPPINTEROP_TARGET}  pugixml argparse::argparse CURL::libcurl)
     else ()
-        target_link_libraries(${target_name} PUBLIC ${XEUS_CPP_XEUS_TARGET} clangCppInterOp pugixml argparse::argparse)
+        target_link_libraries(${target_name} PUBLIC ${XEUS_CPP_XEUS_TARGET} ${CPPINTEROP_TARGET} pugixml argparse::argparse)
     endif()
     
     if (WIN32 OR CYGWIN)

--- a/share/jupyter/kernels/xc11/wasm_kernel.json.in
+++ b/share/jupyter/kernels/xc11/wasm_kernel.json.in
@@ -14,7 +14,7 @@
     "debugger": false,
     "shared": {
       "libxeus.so": "lib/libxeus.so",
-      "libclangCppInterOp.so": "lib/libclangCppInterOp.so"
+      "lib@CPPINTEROP_TARGET@.so": "lib/lib@CPPINTEROP_TARGET@.so"
     }
   }
 }

--- a/share/jupyter/kernels/xc17/wasm_kernel.json.in
+++ b/share/jupyter/kernels/xc17/wasm_kernel.json.in
@@ -14,7 +14,7 @@
     "debugger": false,
     "shared": {
       "libxeus.so": "lib/libxeus.so",
-      "libclangCppInterOp.so": "lib/libclangCppInterOp.so"
+      "lib@CPPINTEROP_TARGET@.so": "lib/lib@CPPINTEROP_TARGET@.so"
     }
   }
 }

--- a/share/jupyter/kernels/xc23/wasm_kernel.json.in
+++ b/share/jupyter/kernels/xc23/wasm_kernel.json.in
@@ -14,7 +14,7 @@
     "debugger": false,
     "shared": {
       "libxeus.so": "lib/libxeus.so",
-      "libclangCppInterOp.so": "lib/libclangCppInterOp.so"
+      "lib@CPPINTEROP_TARGET@.so": "lib/lib@CPPINTEROP_TARGET@.so"
     }
   }
 }

--- a/share/jupyter/kernels/xcpp17/wasm_kernel.json.in
+++ b/share/jupyter/kernels/xcpp17/wasm_kernel.json.in
@@ -13,7 +13,7 @@
     "debugger": false,
     "shared": {
       "libxeus.so": "lib/libxeus.so",
-      "libclangCppInterOp.so": "lib/libclangCppInterOp.so"
+      "lib@CPPINTEROP_TARGET@.so": "lib/lib@CPPINTEROP_TARGET@.so"
     }
   }
 }

--- a/share/jupyter/kernels/xcpp20/wasm_kernel.json.in
+++ b/share/jupyter/kernels/xcpp20/wasm_kernel.json.in
@@ -13,7 +13,7 @@
     "debugger": false,
     "shared": {
       "libxeus.so": "lib/libxeus.so",
-      "libclangCppInterOp.so": "lib/libclangCppInterOp.so"
+      "lib@CPPINTEROP_TARGET@.so": "lib/lib@CPPINTEROP_TARGET@.so"
     }
   }
 }

--- a/share/jupyter/kernels/xcpp23/wasm_kernel.json.in
+++ b/share/jupyter/kernels/xcpp23/wasm_kernel.json.in
@@ -13,7 +13,7 @@
     "debugger": false,
     "shared": {
       "libxeus.so": "lib/libxeus.so",
-      "libclangCppInterOp.so": "lib/libclangCppInterOp.so"
+      "lib@CPPINTEROP_TARGET@.so": "lib/lib@CPPINTEROP_TARGET@.so"
     }
   }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,9 +81,9 @@ if(EMSCRIPTEN)
 
     add_custom_command(TARGET test_xeus_cpp POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_INSTALL_PREFIX}/lib/libclangCppInterOp.so
-        ${CMAKE_CURRENT_BINARY_DIR}/libclangCppInterOp.so
-        COMMENT "Copying libclangCppInterOp.so to the test directory"
+        ${CMAKE_INSTALL_PREFIX}/lib/lib${CPPINTEROP_TARGET}.so
+        ${CMAKE_CURRENT_BINARY_DIR}/lib${CPPINTEROP_TARGET}.so
+        COMMENT "Copying lib${CPPINTEROP_TARGET}.so to the test directory"
     )
 
     add_custom_command(TARGET test_xeus_cpp POST_BUILD


### PR DESCRIPTION
This PR is to stop https://github.com/compiler-research/CppInterOp/pull/882 being a breaking change as far as xeus-cpp is concerned. The library is changing name. This PR intends to extract the target name from the library, and configure xeus-cpp accordingly. 

There is probably be a better way to do this, but this is what I came up with.