### PR TITLE
fix: include <sstream> in audio cell of demo notebook

### DIFF
--- a/test/Notebooks/xeus-cpp.ipynb
+++ b/test/Notebooks/xeus-cpp.ipynb
@@ -358,6 +358,7 @@
    "source": [
     "#include <string>\n",
     "#include <fstream>\n",
+    "#include <sstream>\n",
     "\n",
     "#include \"nlohmann/json.hpp\"\n",
     "\n",


### PR DESCRIPTION
Closes #480.

Adds `#include <sstream>` to the audio cell of `test/Notebooks/xeus-cpp.ipynb`. The cell uses `std::stringstream` (`au::audio::m_buffer`) without the corresponding header, so toolchains that don't transitively include `<sstream>` via `<string>`/`<fstream>` fail to compile the cell, which is what produced the failure in #480.

The companion wasm demo notebook (referenced by @anutosh491 in the issue) already has the include — this brings the desktop demo in line.

Single-line, JSON-valid edit (the notebook still parses cleanly with `json.load`).