### PR TITLE
dev: Normalize `cppiterop` specification in dev environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,6 +357,7 @@ jobs:
             echo "Running test_xeus_cpp in Google Chrome"
             python ${{ env.BUILD_PREFIX }}/bin/emrun.py --browser="Google Chrome" --kill_exit --timeout 60 --browser-args="--headless  --no-sandbox"  test_xeus_cpp.html
             sudo safaridriver --enable
+            python -m ensurepip
             python -m pip install selenium
             echo "Running test_xeus_cpp in Safari"
             python ${{ env.BUILD_PREFIX }}/bin/emrun.py --no_browser --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  test_xeus_cpp.html &

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - xeus-zmq
   - nlohmann_json
   - nlohmann_json-abi
-  - CppInterOp>=1.9
+  - cppinterop>=1.9
   - pugixml
   - cpp-argparse
   - sel(unix): llvm-openmp=21

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -7,7 +7,7 @@ dependencies:
   - nlohmann_json-abi
   - xeus-lite
   - xeus
-  - CppInterOp>=1.9
+  - cppinterop>=1.9
   - cpp-argparse
   - pugixml
   - doctest


### PR DESCRIPTION
# Description

micromamba 2.6.0 appears to be case-sensitive on `MatchSpec` in some context.

I can reproduce the error as of `main` and cannot with the change proposed by this PR.

Fixes #482.

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Added/removed dependencies
- [ ] Required documentation updates
