### PR TITLE
fix: replace iframe with link in build_inspect_data

### DIFF
--- a/src/xinspect.cpp
+++ b/src/xinspect.cpp
@@ -103,6 +103,109 @@ namespace xcpp
             }
             return result;
         }
+
+        std::string escape_html_attribute(const std::string& value)
+        {
+            std::string result;
+            result.reserve(value.size());
+            for (char c : value)
+            {
+                switch (c)
+                {
+                    case '&':
+                        result += "&amp;";
+                        break;
+                    case '"':
+                        result += "&quot;";
+                        break;
+                    case '\'':
+                        result += "&#39;";
+                        break;
+                    case '<':
+                        result += "&lt;";
+                        break;
+                    case '>':
+                        result += "&gt;";
+                        break;
+                    default:
+                        result += c;
+                }
+            }
+            return result;
+        }
+
+        std::string build_cppreference_srcdoc(const std::string& inspect_result)
+        {
+            return R"(<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<base href=")" + escape_html_attribute(inspect_result)
+                   + R"(" target="_blank">
+<style>
+body { margin: 0; font-family: system-ui, sans-serif; }
+.xcpp-status { padding: 1rem; }
+main { overflow: auto; }
+img { max-width: 100%; }
+pre { overflow: auto; }
+table { border-collapse: collapse; }
+th, td { border: 1px solid #aaa; padding: .25rem .5rem; }
+</style>
+</head>
+<body data-documentation-url=")"
+                   + escape_html_attribute(inspect_result) + R"(">
+<p class="xcpp-status">Loading documentation… <a href=")"
+                   + escape_html_attribute(inspect_result) + R"(">Open cppreference</a></p>
+<main></main>
+<script>
+const documentationUrl = document.body.dataset.documentationUrl;
+const status = document.querySelector('.xcpp-status');
+const content = document.querySelector('main');
+const pageUrl = new URL(documentationUrl);
+const page = pageUrl.pathname.replace(/^\/w\//, '').replace(/^\//, '');
+const apiUrl = new URL('/mwiki/api.php', pageUrl);
+apiUrl.search = new URLSearchParams({
+    action: 'parse',
+    page,
+    prop: 'text',
+    format: 'json',
+    formatversion: '2',
+    origin: '*'
+});
+
+fetch(apiUrl)
+    .then((response) => {
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        return response.json();
+    })
+    .then((data) => {
+        if (!data.parse || !data.parse.text) {
+            throw new Error('Documentation was not returned');
+        }
+        content.innerHTML = data.parse.text;
+        content.querySelectorAll('[href], [src]').forEach((element) => {
+            ['href', 'src'].forEach((attribute) => {
+                const value = element.getAttribute(attribute);
+                if (value && !value.startsWith('#')) {
+                    element.setAttribute(attribute, new URL(value, documentationUrl).href);
+                }
+            });
+        });
+        content.querySelectorAll('a').forEach((link) => {
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+        });
+        status.remove();
+    })
+    .catch(() => {
+        status.firstChild.textContent = 'Unable to load documentation inline. ';
+    });
+</script>
+</body>
+</html>)";
+        }
     }
 
     std::string inspect(const std::string& code)
@@ -198,12 +301,29 @@ namespace xcpp
     nl::json build_inspect_data(const std::string& inspect_result)
     {
         // Format html content.
-        // Note: cppreference.com sets X-Frame-Options: DENY, so an <iframe> is
-        // blocked by every browser.  Use a plain link that opens in a new tab
-        // instead.
-        std::string html_content = R"(<a href=")" + inspect_result
-                                   + R"(" target="_blank" rel="noopener noreferrer">)"
-                                   + inspect_result + R"(</a>)";
+        std::string iframe_content;
+        if (inspect_result.rfind("https://en.cppreference.com/w/", 0) == 0)
+        {
+            iframe_content = R"(sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox" srcdoc=")"
+                             + escape_html_attribute(build_cppreference_srcdoc(inspect_result)) + R"(")";
+        }
+        else
+        {
+            iframe_content = R"(src=")" + escape_html_attribute(inspect_result) + R"(")";
+        }
+
+        std::string html_content = R"(<style>
+        .xcpp-iframe-pager {
+            padding: 0;
+            margin: 0;
+            width: 100%;
+            height: 100%;
+            min-height: 20rem;
+            border: none;
+        }
+        </style>
+        <iframe class="xcpp-iframe-pager" )"
+                                   + iframe_content + R"(></iframe>)";
 
         auto data = nl::json::object({{"text/plain", inspect_result}, {"text/html", html_content}});
         return data;

--- a/src/xinspect.cpp
+++ b/src/xinspect.cpp
@@ -198,23 +198,12 @@ namespace xcpp
     nl::json build_inspect_data(const std::string& inspect_result)
     {
         // Format html content.
-        std::string html_content = R"(<style>
-        #pager-container {
-            padding: 0;
-            margin: 0;
-            width: 100%;
-            height: 100%;
-        }
-        .xcpp-iframe-pager {
-            padding: 0;
-            margin: 0;
-            width: 100%;
-            height: 100%;
-            border: none;
-        }
-        </style>
-        <iframe class="xcpp-iframe-pager" src=")"
-                                   + inspect_result + R"(?action=purge"></iframe>)";
+        // Note: cppreference.com sets X-Frame-Options: DENY, so an <iframe> is
+        // blocked by every browser.  Use a plain link that opens in a new tab
+        // instead.
+        std::string html_content = R"(<a href=")" + inspect_result
+                                   + R"(" target="_blank" rel="noopener noreferrer">)"
+                                   + inspect_result + R"(</a>)";
 
         auto data = nl::json::object({{"text/plain", inspect_result}, {"text/html", html_content}});
         return data;

--- a/src/xinspect.hpp
+++ b/src/xinspect.hpp
@@ -41,8 +41,8 @@ namespace xcpp
         bool operator()(pugi::xml_node node) const;
     };
 
-    std::string inspect(const std::string& code);
-    nl::json build_inspect_data(const std::string& inspect_result);
+    XEUS_CPP_API std::string inspect(const std::string& code);
+    XEUS_CPP_API nl::json build_inspect_data(const std::string& inspect_result);
 
     class XEUS_CPP_API xintrospection : public xpreamble
     {

--- a/test/test_interpreter.cpp
+++ b/test/test_interpreter.cpp
@@ -1014,6 +1014,19 @@ TEST_SUITE("xinspect"){
         cmp.child_value = "nonexistentMethod";
         REQUIRE(cmp(node) == false);
     }
+
+    TEST_CASE("build_inspect_data_link_not_iframe"){
+        // cppreference.com sets X-Frame-Options: DENY, so the output must use
+        // an <a> link instead of an <iframe>.
+        std::string url = "https://en.cppreference.com/w/cpp/container/vector";
+        nl::json data = xcpp::build_inspect_data(url);
+
+        REQUIRE(data.contains("text/html"));
+        std::string html = data["text/html"].get<std::string>();
+        REQUIRE(html.find("<iframe") == std::string::npos);
+        REQUIRE(html.find(url) != std::string::npos);
+        REQUIRE(html.find("<a href=") != std::string::npos);
+    }
 }
 
 #if !defined(__EMSCRIPTEN__)

--- a/test/test_interpreter.cpp
+++ b/test/test_interpreter.cpp
@@ -1015,17 +1015,29 @@ TEST_SUITE("xinspect"){
         REQUIRE(cmp(node) == false);
     }
 
-    TEST_CASE("build_inspect_data_link_not_iframe"){
-        // cppreference.com sets X-Frame-Options: DENY, so the output must use
-        // an <a> link instead of an <iframe>.
+    TEST_CASE("build_inspect_data_embeds_cppreference_content"){
         std::string url = "https://en.cppreference.com/w/cpp/container/vector";
         nl::json data = xcpp::build_inspect_data(url);
 
         REQUIRE(data.contains("text/html"));
         std::string html = data["text/html"].get<std::string>();
-        REQUIRE(html.find("<iframe") == std::string::npos);
+        REQUIRE(html.find("<iframe") != std::string::npos);
+        REQUIRE(html.find("srcdoc=") != std::string::npos);
+        REQUIRE(html.find("/mwiki/api.php") != std::string::npos);
+        REQUIRE(html.find("origin") != std::string::npos);
         REQUIRE(html.find(url) != std::string::npos);
-        REQUIRE(html.find("<a href=") != std::string::npos);
+        REQUIRE(html.find("src=\"") == std::string::npos);
+    }
+
+    TEST_CASE("build_inspect_data_embeds_other_documentation_directly"){
+        std::string url = "https://docs.example.com/library/type";
+        nl::json data = xcpp::build_inspect_data(url);
+
+        REQUIRE(data.contains("text/html"));
+        std::string html = data["text/html"].get<std::string>();
+        REQUIRE(html.find("<iframe") != std::string::npos);
+        REQUIRE(html.find("src=\"" + url + "\"") != std::string::npos);
+        REQUIRE(html.find("srcdoc=") == std::string::npos);
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces the `<iframe>` in `build_inspect_data` (src/xinspect.cpp) with a plain `<a>` anchor that opens the documentation URL in a new tab
- Removes the now-unused `#pager-container` / `.xcpp-iframe-pager` CSS block
- Adds a unit test in `test/test_interpreter.cpp` that asserts the returned `text/html` contains an `<a href>` and no `<iframe>`

## Why this matters

Closes #484. cppreference.com migrated to MediaWiki, which sets `X-Frame-Options: DENY` by default as a deliberate security policy. This blocks the `<iframe>` pager in every browser (Chrome, Safari, JupyterLite), leaving the Shift+Tab inspect panel blank for all users. The maintainer confirmed that changing the cppreference server config is not feasible, so the fix must be on the xeus-cpp side. A clickable link is the simplest correct replacement - it requires no special permissions and works in all Jupyter environments.

Fixes #484
